### PR TITLE
Fix for IPoker hands from miners

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Compression\HandHistoryGZipCompressorImplTests.cs" />
     <Compile Include="Infrastructure\NinjectKernel.cs" />
     <Compile Include="Parsers\Base\HandHistoryParserBaseTests.cs" />
+    <Compile Include="Parsers\FastParserTests\IPoker\IPokerExtraTests.cs" />
     <Compile Include="Parsers\FastParserTests\PokerStars\PokerStarsFastParserActionTests.cs" />
     <Compile Include="Parsers\HandParserTests\CommunityCardTests\HandParserCommunityCardTests.cs" />
     <Compile Include="Parsers\HandParserTests\HandActionTests\HandParserHandActionTestsBossMedia.cs" />
@@ -290,6 +291,9 @@
     </Content>
     <Content Include="SampleHandHistories\FullTilt\CashGame\ValidHandTests\ValidHand.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SampleHandHistories\IPoker\CashGame\ExtraHands\DataMinerHandIssue1.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SampleHandHistories\IPoker\CashGame\HandActionTests\AnteAction.txt" />
     <Content Include="SampleHandHistories\IPoker\CashGame\MultipleHandsTests\MinerFormat.txt">

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/IPoker/IPokerExtraTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/IPoker/IPokerExtraTests.cs
@@ -1,0 +1,74 @@
+﻿using HandHistories.Objects.GameDescription;
+using HandHistories.Objects.Hand;
+using HandHistories.Parser.UnitTests.Parsers.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.IPoker
+{
+    [TestFixture]
+    class IPokerExtraTests : HandHistoryParserBaseTests 
+    {
+        public IPokerExtraTests() : base("IPoker")
+        {
+        }
+
+        private HandHistory TestFullHandHistory(HandHistory expectedHand, string fileName)
+        {
+            string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "ExtraHands", fileName);
+
+            HandHistory actualHand = GetParser().ParseFullHandHistory(handText, true);
+
+            Assert.AreEqual(expectedHand.GameDescription, actualHand.GameDescription);
+            Assert.AreEqual(expectedHand.DealerButtonPosition, actualHand.DealerButtonPosition);
+            Assert.AreEqual(expectedHand.DateOfHandUtc, actualHand.DateOfHandUtc);
+            Assert.AreEqual(expectedHand.HandId, actualHand.HandId);
+            Assert.AreEqual(expectedHand.NumPlayersSeated, actualHand.NumPlayersSeated);
+            Assert.AreEqual(expectedHand.TableName, actualHand.TableName);
+
+            return actualHand;
+        }
+
+        private HandHistorySummary TestFullHandHistorySummary(HandHistorySummary expectedSummary, string fileName)
+        {
+            string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "ExtraHands", fileName);
+
+            HandHistorySummary actualSummary = GetSummmaryParser().ParseFullHandSummary(handText, true);
+
+            Assert.AreEqual(expectedSummary.GameDescription, actualSummary.GameDescription);
+            Assert.AreEqual(expectedSummary.DealerButtonPosition, actualSummary.DealerButtonPosition);
+            Assert.AreEqual(expectedSummary.DateOfHandUtc, actualSummary.DateOfHandUtc);
+            Assert.AreEqual(expectedSummary.HandId, actualSummary.HandId);
+            Assert.AreEqual(expectedSummary.NumPlayersSeated, actualSummary.NumPlayersSeated);
+            Assert.AreEqual(expectedSummary.TableName, actualSummary.TableName);
+
+            return actualSummary;
+        }
+
+        [Test]
+        public void HandIssue1()
+        {
+            HandHistory expectedSummary = new HandHistory()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(5m, 10m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.IPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Regular)
+                },
+                DateOfHandUtc = new DateTime(2014, 1, 1, 22, 50, 13),
+                DealerButtonPosition = 1,
+                HandId = 987654,
+                NumPlayersSeated = 5,
+                TableName = "Andreapol__No_DP_"
+            };
+            TestFullHandHistorySummary(expectedSummary, "DataMinerHandIssue1");
+        }
+    }
+}

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/IPoker/CashGame/ExtraHands/DataMinerHandIssue1.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/IPoker/CashGame/ExtraHands/DataMinerHandIssue1.txt
@@ -1,0 +1,56 @@
+﻿<session sessioncode="123456">
+<general>
+<mode>real</mode>
+<gametype>Holdem NL 5/10</gametype>
+<tablename>Andreapol__No_DP_</tablename>
+<duration>N/A</duration>
+<gamecount>N/A</gamecount>
+<startdate>2014-01-01 22:50:13</startdate>
+<currency>USD</currency>
+<nickname>N/A</nickname>
+<bets>N/A</bets>
+<wins>N/A</wins>
+<chipsin>N/A</chipsin>
+<chipsout>N/A</chipsout>
+<ipoints>N/A</ipoints>
+</general>
+<game gamecode="987654">
+<general>
+<startdate>2014-01-01 22:50:13</startdate>
+<players>
+<player seat="5" name="ch4atsftw" chips="$100000" dealer="0" win="$0" bet="$0" />
+<player seat="4" name="Marlene79" chips="$100000" dealer="0" win="$0" bet="$0" />
+<player seat="3" name="Shostak0vich" chips="$100000" dealer="0" win="$0" bet="$20" />
+<player seat="2" name="Betraktaren" chips="$100000" dealer="0" win="$0" bet="$5" />
+<player seat="1" name="a3uu" chips="$100000" dealer="1" win="$42.75" bet="$20" />
+</players>
+</general>
+<round no="0">
+<action no="1" player="Betraktaren" type="1" sum="$5"/>
+<action no="2" player="Shostak0vich" type="2" sum="$10"/>
+</round>
+<round no="1">
+<cards type="Pocket" player="a3uu"></cards>
+<action no="3" player="Marlene79" type="0" sum="$0"/>
+<action no="4" player="ch4atsftw" type="0" sum="$0"/>
+<action no="5" player="a3uu" type="23" sum="$20"/>
+<action no="6" player="Betraktaren" type="0" sum="$0"/>
+<action no="7" player="Shostak0vich" type="3" sum="$10"/>
+</round>
+<round no="2">
+<cards type="Flop" player="">c10 hK s5</cards>
+<action no="8" player="Shostak0vich" type="4" sum="$0"/>
+<action no="9" player="a3uu" type="4" sum="$0"/>
+</round>
+<round no="3">
+<cards type="Turn" player="">h3</cards>
+<action no="10" player="Shostak0vich" type="4" sum="$0"/>
+<action no="11" player="a3uu" type="4" sum="$0"/>
+</round>
+<round no="4">
+<cards type="River" player="">dJ</cards>
+<action no="12" player="Shostak0vich" type="4" sum="$0"/>
+<action no="13" player="a3uu" type="4" sum="$0"/>
+</round>
+</game>
+</session>

--- a/HandHistories.Parser/Parsers/FastParser/IPoker/IPokerFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/IPoker/IPokerFastParserImpl.cs
@@ -287,7 +287,8 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
               </players>             
              */
 
-            int offset = 23;
+
+            int offset = GetFirstPlayerIndex(handLines);
             List<string> playerLines = new List<string>();
 
             string line = handLines[offset];
@@ -305,6 +306,18 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
             }
 
             return playerLines.ToArray();
+        }
+
+        private int GetFirstPlayerIndex(string[] handLines)
+        {
+            for (int i = 18; i < handLines.Length; i++)
+            {
+                if (handLines[i][1] == 'p')
+                {
+                    return i + 1;
+                }
+            }
+            throw new IndexOutOfRangeException("Did not find first player");
         }
 
         protected string[] GetCardLinesFromHandLines(string[] handLines)
@@ -381,7 +394,11 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
 
         protected override Limit ParseLimit(string[] handLines)
         {
-            //GameType line = <gametype>Holdem NL $0.02/$0.04</gametype>
+            //Limit line format:
+            //<gametype>Holdem NL $0.02/$0.04</gametype>
+            //Alternative1:
+            //<gametype>Holdem NL 0.02/0.04</gametype>
+            //<currency>USD</currency>
             string gameTypeLine = GetGameTypeLineFromHandLines(handLines);
             int limitStringBeginIndex = gameTypeLine.LastIndexOf(' ') + 1;
             int limitStringEndIndex = gameTypeLine.LastIndexOf('<') - 1;
@@ -395,27 +412,62 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
             {
                 case '$':
                     currency = Currency.USD;
+                    limitString = limitString.Substring(1);
                     break;
                 case '€':
                     currency = Currency.EURO;
+                    limitString = limitString.Substring(1);
                     break;
                 case '£':
                     currency = Currency.GBP;
+                    limitString = limitString.Substring(1);
                     break;
                 default:
-                    throw new LimitException(handLines[0], "Unrecognized currency symbol " + currencySymbol);
+                    string tagValue = GetCurrencyTagValue(handLines);
+                    switch (tagValue)
+                    {
+                        case "USD":
+                            currency = Currency.USD;
+                            break;
+                        case "GBP":
+                            currency = Currency.GBP;
+                            break;
+                        case "EUR":
+                            currency = Currency.EURO;
+                            break;
+                        default:
+                            throw new LimitException(handLines[0], "Unrecognized currency symbol " + currencySymbol);
+                    }
+                    break;
             }
 
             int slashIndex = limitString.IndexOf('/');
 
-            string smallString = limitString.Substring(1, slashIndex - 1);
+            string smallString = limitString.Remove(slashIndex);
             decimal small = decimal.Parse(smallString, System.Globalization.CultureInfo.InvariantCulture);
-
  
-            string bigString = limitString.Substring(slashIndex + 2, limitString.Length - (slashIndex + 2));
+            string bigString = limitString.Substring(slashIndex + 1);
+            if (bigString[0] == '£' || bigString[0] == '$' || bigString[0] == '€')
+            {
+                bigString = bigString.Substring(1);
+            }
             decimal big = decimal.Parse(bigString, System.Globalization.CultureInfo.InvariantCulture);
 
             return Limit.FromSmallBlindBigBlind(small, big, currency);
+        }
+
+        private string GetCurrencyTagValue(string[] handLines)
+        {
+            for (int i = 0; i < 11; i++)
+            {
+                string handline = handLines[i];
+                if (handline[1] == 'c' && handline[2] == 'u')
+                {
+                    int endIndex = handline.IndexOf('<', 10);
+                    return handline.Substring(10, endIndex - 10);
+                }
+            }
+            return "";
         }
 
         public override bool IsValidHand(string[] handLines)
@@ -423,12 +475,6 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
             //Check 1 - Are we in a Session Tag
             if (handLines[0].StartsWith("<session") == false ||
                 handLines[handLines.Length - 1].StartsWith("</session") == false)
-            {
-                return false;
-            }
-
-            //Check 2 - Do we have a Game Tag
-            if (handLines[19].StartsWith("<game") == false && handLines[20].StartsWith("<game") == false)
             {
                 return false;
             }
@@ -456,7 +502,6 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
 
             string[] playerLines = GetPlayerLinesFromHandLines(handLines);
             //The 2nd line after the </player> line is the beginning of the <round> rows
-
 
             int offset =  23;
 
@@ -628,6 +673,8 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
             /*
                 <player seat="3" name="RodriDiaz3" chips="$2.25" dealer="0" win="$0" bet="$0.08" rebuy="0" addon="0" />
                 <player seat="8" name="Kristi48ru" chips="$6.43" dealer="1" win="$0.23" bet="$0.16" rebuy="0" addon="0" />
+                or
+                <player seat="5" name="player5" chips="$100000" dealer="0" win="$0" bet="$0" />
              */
 
             string[] playerLines = GetPlayerLinesFromHandLines(handLines);
@@ -692,8 +739,12 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
                     continue;
                 }
 
-                //When players fold, we see a line: <cards type="Pocket" player="pepealas5">X X</cards>, we should skip these lines
-                if (handLine[handLine.Length - 9] == 'X')
+                //When players fold, we see a line: 
+                //<cards type="Pocket" player="pepealas5">X X</cards>
+                //or:
+                //<cards type="Pocket" player="playername"></cards>
+                //We skip these lines
+                if (handLine[handLine.Length - 9] == 'X' || handLine[handLine.Length - 9] == '>')
                 {
                     continue;
                 }
@@ -710,7 +761,7 @@ namespace HandHistories.Parser.Parsers.FastParser.IPoker
                 string playerCardString = handLine.Substring(playerCardsStartIndex,
                                                         playerCardsEndIndex - playerCardsStartIndex + 1);
                 string[] cards = playerCardString.Split(' ');
-                if (cards.Length > 0)
+                if (cards.Length > 1)
                 {
                     player.HoleCards = HoleCards.NoHolecards(player.PlayerName);
                     foreach (string card in cards)


### PR DESCRIPTION
This fixes issues with certain data miners that use a different format. A test is provided in path: ...\HandHistories.Parser.UnitTests\SampleHandHistories\IPoker\CashGame\ExtraHands\DataMinerHandIssue1.txt
