### PR TITLE
IEnumerable<HandAction> extensions

### DIFF
--- a/HandHistories.Objects/Actions/HandAction.cs
+++ b/HandHistories.Objects/Actions/HandAction.cs
@@ -22,7 +22,7 @@ namespace HandHistories.Objects.Actions
         public Street Street { get; private set; }
 
         [DataMember]
-        public int ActionNumber { get; private set; }
+        public int ActionNumber { get; set; }
 
         [DataMember]
         public bool IsAllIn { get; private set; }

--- a/HandHistories.Objects/Utils/HandAction.Extensions.cs
+++ b/HandHistories.Objects/Utils/HandAction.Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using HandHistories.Objects.Actions;
 using HandHistories.Objects.Cards;
+using HandHistories.Objects.Players;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,9 +15,24 @@ namespace HandHistories.Objects.Actions
             return actions.Where(p => p.Street == street);
         }
 
+        public static IEnumerable<HandAction> Street(this IEnumerable<HandAction> actions, HandAction action)
+        {
+            return actions.Where(p => p.Street == action.Street);
+        }
+
         public static IEnumerable<HandAction> Player(this IEnumerable<HandAction> actions, string PlayerName)
         {
             return actions.Where(p => p.PlayerName == PlayerName);
+        }
+
+        public static IEnumerable<HandAction> Player(this IEnumerable<HandAction> actions, HandAction action)
+        {
+            return actions.Where(p => p.PlayerName == action.PlayerName);
+        }
+
+        public static IEnumerable<HandAction> Player(this IEnumerable<HandAction> actions, Player action)
+        {
+            return actions.Where(p => p.PlayerName == action.PlayerName);
         }
     }
 }

--- a/HandHistories.Parser/Parsers/FastParser/888/Poker888FastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/888/Poker888FastParserImpl.cs
@@ -16,7 +16,7 @@ using HandHistories.Parser.Utils.Extensions;
 
 namespace HandHistories.Parser.Parsers.FastParser._888
 {
-    sealed class Poker888FastParserImpl : HandHistoryParserFastImpl
+    public sealed class Poker888FastParserImpl : HandHistoryParserFastImpl
     {
         public override SiteName SiteName
         {


### PR DESCRIPTION
Adding:
IEnumerable<HandAction>.Player(HandAction)
IEnumerable<HandAction>.Player(Player)
IEnumerable<HandAction>.Street(HandAction)

Making setHandActionNumber() public and making the 888Parser constructor
public.