### PR TITLE
PokerStars: adding AllInFlop test + fix

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1103,6 +1103,9 @@
     <Content Include="SampleHandHistories\PokerStars\CashGame\Seats\HeadsUp.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleHandHistories\PokerStars\CashGame\ShowDownActionTests\AllinFlop.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleHandHistories\PokerStars\CashGame\ShowDownActionTests\Ignore.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/HandHistories.Parser.UnitTests/Parsers/ThreeStateParserTests/ThreeStateParserTestsPokerStars.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/ThreeStateParserTests/ThreeStateParserTestsPokerStars.cs
@@ -1,5 +1,6 @@
 ﻿using HandHistories.Objects.Actions;
 using HandHistories.Objects.Cards;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,6 +40,18 @@ namespace HandHistories.Parser.UnitTests.Parsers.ThreeStateParserTests
                         new WinningsAction("numbush", HandActionType.WINS, 23.57m, 0),
                     };
             }
+        }
+
+        [Test]
+        public void  ExpectedShowDownActions_AllInFlop()
+        {
+            var actions = new List<HandAction>()
+                    {
+                        new HandAction("danfiu", HandActionType.SHOW, Street.Showdown),
+                        new HandAction("KENZA_MILOU", HandActionType.SHOW, Street.Showdown),
+                        new WinningsAction("danfiu", HandActionType.WINS, 1097.32m, 0),
+                    };
+            TestShowDownActions("AllinFlop", actions);
         }
     }
 }

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/ShowDownActionTests/AllinFlop.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/ShowDownActionTests/AllinFlop.txt
@@ -1,0 +1,7 @@
+﻿*** TURN *** [Ad 2d 3c] [5d]
+*** RIVER *** [Ad 2d 3c 5d] [Jh]
+*** SHOW DOWN ***
+danfiu: shows [5h Kh Ah Ks] (two pair, Aces and Fives)
+KENZA_MILOU: shows [8c Th 8s 3d] (a pair of Eights)
+danfiu collected $1097.32 from pot
+*** SUMMARY ***

--- a/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
@@ -522,7 +522,12 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
                         continue;
 
                     //*** SUMMARY ***
+                    //*** SHOW DOWN ***
                     case '*':
+                        if (line[5] == 'H')
+                        {
+                            continue;
+                        }
                         return;
 
                     //No low hand qualified


### PR DESCRIPTION
*** TURN *** [Ad 2d 3c] [5d]
*** RIVER *** [Ad 2d 3c 5d] [Jh]
*** SHOW DOWN ***
danfiu: shows [5h Kh Ah Ks] (two pair, Aces and Fives)
KENZA_MILOU: shows [8c Th 8s 3d] (a pair of Eights)
danfiu collected $1097.32 from pot
*** SUMMARY ***