### PR TITLE
Fixing bug with SplitUpMultipleHandsToLines

### DIFF
--- a/HandHistories.Parser.WindowsTestApp/ParserTestForm.cs
+++ b/HandHistories.Parser.WindowsTestApp/ParserTestForm.cs
@@ -69,9 +69,6 @@ namespace HandHistories.Parser.WindowsTestApp
 
                 MessageBox.Show(this, "Parsed " + parsedHands + " hands." + Math.Round(SW.Elapsed.TotalMilliseconds, 2) + "ms");
             }
-            catch (RunItTwiceHandException ex)
-            {
-            }
             catch (Exception ex)
             {
                 MessageBox.Show(this, ex.Message + "\r\n" + ex.StackTrace, "Error");

--- a/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
@@ -79,6 +79,11 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
                 }
                 handLines.Add(item.TrimEnd('\r', ' '));
             }
+
+            if (handLines.Count > 0)
+            {
+                yield return handLines.ToArray();
+            }
         }
 
         protected override int ParseDealerPosition(string[] handLines)


### PR DESCRIPTION
Fixing bug with SplitUpMultipleHandsToLines where the last hand would
not be parsed.
Removing RunItTwiceException filter from the TestApp