### PR TITLE
PokerStars: Fixing parse of non-showdown show+test

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1112,6 +1112,9 @@
     <Content Include="SampleHandHistories\PokerStars\CashGame\PlayerTests\RunItTwice.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleHandHistories\PokerStars\CashGame\PlayerTests\ShowWithoutShowdown.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleHandHistories\PokerStars\CashGame\PlayerTests\WithShowdown.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/HandHistories.Parser.UnitTests/Parsers/HandParserTests/Players/HandParserPlayersTestsPokerStarsImpl.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/HandParserTests/Players/HandParserPlayersTestsPokerStarsImpl.cs
@@ -14,14 +14,31 @@ namespace HandHistories.Parser.UnitTests.Parsers.HandParserTests.Players
         }
 
         [Test]
-        public void ParsePlayers_NoHoleCards()
+        public void ParsePlayers_ShowWithoutShowdown()
         {
-            //Seat 1: jedimaster82 ($1000 in chips) 
-            //Seat 2: OneMoreSpin ($1859.80 in chips) 
-            //Seat 3: FLATC@T ($2000 in chips) 
-            //Seat 4: KENZA_MILOU ($1000 in chips) 
-            //Seat 5: Legheliel ($2000 in chips) 
-            //Seat 6: danfiu ($2000 in chips) 
+            var expected = new PlayerList(new List<Player>()
+            {
+                new Player("TheHoboKing", 187.76m, 1),
+                new Player("gio_pot7", 1312.61m, 2),
+                new Player("princepemega", 237.45m, 3),
+                new Player("Chip-phage", 400m, 4)
+                {
+                    HoleCards = HoleCards.ForOmaha(
+                    new Card('2', 'c'), 
+                    new Card('7', 'd'),
+                    new Card('8', 'c'),
+                    new Card('Q', 'h'))
+                },
+                new Player("YoungAKGun", 657.14m, 5),
+                new Player("Zsipali", 432.12m, 6),
+            });
+
+            TestParsePlayers("ShowWithoutShowdown", expected);
+        }
+
+        [Test]
+        public void ParsePlayers_RunItTwice()
+        {
             var expected = new PlayerList(new List<Player>()
             {
                 new Player("jedimaster82", 1000, 1),

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/PlayerTests/ShowWithoutShowdown.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/PlayerTests/ShowWithoutShowdown.txt
@@ -1,0 +1,38 @@
+﻿PokerStars Game #134109689886:  Omaha Pot Limit ($2/$4 USD) - 2015/04/21 19:48:33 ET
+Table 'Hydra III' 6-max Seat #2 is the button
+Seat 1: TheHoboKing ($187.76 in chips)
+Seat 2: gio_pot7 ($1312.61 in chips)
+Seat 3: princepemega ($237.45 in chips)
+Seat 4: Chip-phage ($400 in chips)
+Seat 5: YoungAKGun ($657.14 in chips)
+Seat 6: Zsipali ($432.12 in chips)
+princepemega: posts small blind $2
+Chip-phage: posts big blind $4
+*** HOLE CARDS ***
+YoungAKGun: folds
+Zsipali: folds
+TheHoboKing: folds
+gio_pot7: raises $10 to $14
+princepemega: folds
+Chip-phage: calls $10
+*** FLOP *** [7h 5d 4h]
+Chip-phage: checks
+gio_pot7: checks
+*** TURN *** [7h 5d 4h] [Ah]
+Chip-phage: bets $27.79
+gio_pot7: calls $27.79
+*** RIVER *** [7h 5d 4h Ah] [Kh]
+Chip-phage: bets $80.29
+gio_pot7: folds
+Uncalled bet ($80.29) returned to Chip-phage
+Chip-phage collected $82.78 from pot
+Chip-phage: shows [2c 7d 8c Qh] (a pair of Sevens)
+*** SUMMARY ***
+Total pot $85.58 | Rake $2.80
+Board [7h 5d 4h Ah Kh]
+Seat 1: TheHoboKing folded before Flop (didn't bet)
+Seat 2: gio_pot7 (button) folded on the River
+Seat 3: princepemega (small blind) folded before Flop
+Seat 4: Chip-phage (big blind) collected ($82.78)
+Seat 5: YoungAKGun folded before Flop (didn't bet)
+Seat 6: Zsipali folded before Flop (didn't bet)

--- a/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
@@ -1064,6 +1064,32 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
                     playerList[playerName].HoleCards = HoleCards.FromCards(cards);
                 }
             }
+            else
+            {
+                //Check for player shows
+                for (int i = summaryIndex - 1; i > 0; i--)
+                {
+                    string line = handLines[i];
+
+                    if (line.EndsWith(")") && line.Contains(": shows ["))
+                    {
+                        int nameEndIndex = line.IndexOf(": shows [", StringComparison.Ordinal);
+
+                        string playerName = line.Remove(nameEndIndex);
+
+                        int cardsStartIndex = nameEndIndex + 9;
+                        int cardsEndIndex = line.IndexOf(']', cardsStartIndex);
+
+                        string cards = line.Substring(cardsStartIndex, cardsEndIndex - cardsStartIndex);
+
+                        playerList[playerName].HoleCards = HoleCards.FromCards(cards);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
 
             return playerList;
         }


### PR DESCRIPTION
Example:
Chip-phage collected $82.78 from pot
Chip-phage: shows [2c 7d 8c Qh] (a pair of Sevens)
*** SUMMARY ***