### PR TITLE
Add Parser for GGPoker NLH cash game + Unit tests

### DIFF
--- a/HandHistories.Objects.UnitTests/Cards/CardEqualTest.cs
+++ b/HandHistories.Objects.UnitTests/Cards/CardEqualTest.cs
@@ -15,5 +15,26 @@ namespace HandHistories.Objects.UnitTests.Cards
                 throw new Exception("Card: 2c is not equal 2c.");
             }
         }
+        [Test]
+        public void HoleCards_TestEquality_ReturnTrue()
+        {
+            HoleCards holeCards1 = HoleCards.ForHoldem(new Card('2', 'c'), new Card('A', 'S'));
+            HoleCards holeCards2 = HoleCards.ForHoldem(new Card('a', 'S'), new Card('2', 'c'));
+
+            Assert.IsTrue(holeCards1.Equals(holeCards2));
+            Assert.IsTrue(holeCards1 == holeCards2);
+        }
+
+
+        [Test]
+        public void HoleCards_TestEquality_ReturnFalse()
+        {
+            HoleCards holeCards1 = HoleCards.ForHoldem(new Card('k', 'c'), new Card('A', 'S'));
+            HoleCards holeCards2 = HoleCards.ForHoldem(new Card('a', 'S'), new Card('2', 'c'));
+
+            Assert.IsFalse(holeCards1.Equals(holeCards2));
+            Assert.IsFalse(holeCards1 == holeCards2);
+        }
+
     }
 }

--- a/HandHistories.Objects.UnitTests/Hand/RunItTwiceTest.cs
+++ b/HandHistories.Objects.UnitTests/Hand/RunItTwiceTest.cs
@@ -1,0 +1,128 @@
+﻿using HandHistories.Objects.Actions;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.Hand;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HandHistories.Objects.UnitTests.Hand
+{
+    [TestFixture]
+    public class RunItTwiceTest
+    {
+        [Test]
+        public void RunItTwice_TestEquality_ReturnsTrue() 
+        {
+            RunItTwice r1 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("AcKdQd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>() 
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            RunItTwice r2 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QdAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            Assert.IsTrue(r1.Equals(r1));
+            Assert.IsTrue(r1.Equals(r2));
+        }
+
+        [Test]
+        public void RunItTwice_TestEquality_ReturnsFalse()
+        {
+            RunItTwice r1 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QdAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            RunItTwice r2 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QcAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            RunItTwice r3 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QdAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player2", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            RunItTwice r4 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QdAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 120m, 0),
+                    new WinningsAction("player2", WinningsActionType.WINS, 120m, 0)
+                }
+            };
+
+            RunItTwice r5 = new RunItTwice()
+            {
+                Board = BoardCards.FromCards("QdAckd"),
+                Actions = new List<HandAction>()
+                {
+
+                },
+                Winners = new List<WinningsAction>()
+                {
+                    new WinningsAction("player1", WinningsActionType.WINS, 121m, 0)
+                }
+            };
+
+            Assert.IsFalse(r1.Equals(r2));
+            Assert.IsFalse(r1.Equals(r3));
+            Assert.IsFalse(r1.Equals(r4));
+            Assert.IsFalse(r1.Equals(r5));
+            Assert.IsFalse(r2.Equals(r3));
+            Assert.IsFalse(r2.Equals(r4));
+            Assert.IsFalse(r2.Equals(r5));
+            Assert.IsFalse(r3.Equals(r4));
+            Assert.IsFalse(r3.Equals(r5));
+            Assert.IsFalse(r4.Equals(r5));
+        }
+    }
+}

--- a/HandHistories.Objects.UnitTests/PlayerList/PlayerListEqualTest.cs
+++ b/HandHistories.Objects.UnitTests/PlayerList/PlayerListEqualTest.cs
@@ -1,0 +1,83 @@
+﻿using HandHistories.Objects.Players;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HandHistories.Objects.UnitTests.PlayerList
+{
+    [TestFixture]
+    public class CardEqualityTests
+    {
+        [Test]
+        public void Player_TestEquality_ReturnTrue()
+        {
+            Player player = new Player("name_1", 101.5m, 1);
+            Assert.IsTrue(player.Equals(player));
+        }
+
+        [Test]
+        public void Player_TestEquality_ReturnFalse()
+        { 
+            Player player1 = new Player("name_1", 101.5m, 1);
+            Player player2 = new Player("name_1", 102.5m, 1);
+            Player player3 = new Player("name_2", 101.5m, 1);
+            Player player4 = new Player("name_1", 101.5m, 2);
+            
+            Assert.IsFalse(player1.Equals(player2));
+            Assert.IsFalse(player1.Equals(player3));
+            Assert.IsFalse(player1.Equals(player4));
+            Assert.IsFalse(player2.Equals(player3));
+            Assert.IsFalse(player2.Equals(player4));
+            Assert.IsFalse(player3.Equals(player4));
+        }
+
+        [Test]
+        public void PlayerList_TestEquality_ReturnTrue()
+        {
+            Player player1 = new Player("name_1", 101.5m, 0);
+            Player player2 = new Player("name_1", 102.5m, 1);
+            Player player3 = new Player("name_2", 101.5m, 2);
+            Player player4 = new Player("name_1", 101.5m, 3);
+            
+            Players.PlayerList playerList1 = new Players.PlayerList()
+            {
+                player1, player2, player3, player4
+            };
+            Players.PlayerList playerList2 = new Players.PlayerList()
+            {
+                player4, player2, player3, player1
+            };
+            
+            Assert.IsTrue(playerList1.Equals(playerList1));
+            Assert.IsTrue(playerList1.Equals(playerList2));
+        }
+
+        [Test]
+        public void PlayerList_TestEquality_ReturnFalse()
+        {
+            Player player1 = new Player("name_1", 101.5m, 0);
+            Player player2 = new Player("name_1", 102.5m, 1);
+            Player player3 = new Player("name_2", 101.5m, 2);
+            Player player4 = new Player("name_1", 101.5m, 3);
+            
+            Players.PlayerList playerList1 = new Players.PlayerList()
+            {
+                player1, player2, player3, player4
+            };
+            Players.PlayerList playerList2 = new Players.PlayerList()
+            {
+                player1, player2, player4
+            };
+
+            Players.PlayerList playerList3 = new Players.PlayerList()
+            {
+                player1, player3, player4
+            };
+            
+            Assert.IsFalse(playerList1.Equals(playerList2));
+            Assert.IsFalse(playerList2.Equals(playerList3));
+            Assert.IsFalse(playerList1.Equals(playerList3));
+        }
+    }
+}

--- a/HandHistories.Objects.UnitTests/Serialization/SerializationTests.cs
+++ b/HandHistories.Objects.UnitTests/Serialization/SerializationTests.cs
@@ -44,7 +44,7 @@ namespace HandHistories.Objects.UnitTests.Serialization
                                                      },
                                    HandId = HandID.From(141234124),
                                    NumPlayersSeated = 2,
-                                   Players = new PlayerList()
+                                   Players = new Players.PlayerList()
                                                  {
                                                      new Player("Player1", 1000, 1),
                                                      new Player("Player2", 300, 5),

--- a/HandHistories.Objects/Actions/HandAction.cs
+++ b/HandHistories.Objects/Actions/HandAction.cs
@@ -137,6 +137,8 @@ namespace HandHistories.Objects.Actions
                     return amount * -1;
                 case HandActionType.BIG_BLIND:
                     return amount * -1;
+                case HandActionType.STRADDLE:
+                    return amount * -1;
                 case HandActionType.UNCALLED_BET:
                     return amount;
                 case HandActionType.POSTS:

--- a/HandHistories.Objects/Actions/HandActionType.cs
+++ b/HandHistories.Objects/Actions/HandActionType.cs
@@ -15,6 +15,7 @@
         ANTE,
         SMALL_BLIND,
         BIG_BLIND,
+        STRADDLE,
         #endregion
 
         #region Game Actions

--- a/HandHistories.Objects/Cards/CardGroup.cs
+++ b/HandHistories.Objects/Cards/CardGroup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;

--- a/HandHistories.Objects/Cards/CardGroup.cs
+++ b/HandHistories.Objects/Cards/CardGroup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -67,6 +68,8 @@ namespace HandHistories.Objects.Cards
             }
         }
 
+        public List<Card> GetCards() { return Cards; }
+
         public Card this[int i]
         {
             get { return Cards[i]; }
@@ -93,13 +96,32 @@ namespace HandHistories.Objects.Cards
             if (stringEquality) return true;
 
             CardGroup cardGroup = obj as CardGroup;
+
             if (cardGroup == null) return false;
 
             if (cardGroup.Cards.Count != Cards.Count) return false;
 
             return (cardGroup.Cards.All(c => Cards.Contains(c)));
         }
-       
+
+        
+        public static bool operator ==(CardGroup c1, CardGroup c2) 
+        { 
+            if (ReferenceEquals(c1, c2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(c1, null) || ReferenceEquals(c2, null))
+            {
+                return false;
+            }
+
+            return c1.Equals(c2); 
+        }
+        
+
+        public static bool operator !=(CardGroup c1, CardGroup c2) { return !(c1 == c2); }
+
         public override int GetHashCode()
         {
             return (Cards != null ? Cards.GetHashCode() : 0);

--- a/HandHistories.Objects/GameDescription/SiteNames.cs
+++ b/HandHistories.Objects/GameDescription/SiteNames.cs
@@ -38,6 +38,7 @@ namespace HandHistories.Objects.GameDescription
         WinningPokerV2 = 33,
         AsianPokerClubs = 34,
         Upoker = 35,
+        GGPoker = 36,
         All = 63 // note: can't go higher than 63 due to bit value optimizations
     }
 }

--- a/HandHistories.Objects/Hand/HandHistory.cs
+++ b/HandHistories.Objects/Hand/HandHistory.cs
@@ -35,7 +35,9 @@ namespace HandHistories.Objects.Hand
 
         public Player Hero { get; set; }
 
-        public RunItTwice RunItTwiceData { get; set;  }
+        public RunItTwice RunItTwiceData { get; set;  } 
+        
+        public RunItTwice[] RunItMultipleTimes { get; set;  }
 
         public int NumPlayersActive
         {

--- a/HandHistories.Objects/Hand/HandHistorySummary.cs
+++ b/HandHistories.Objects/Hand/HandHistorySummary.cs
@@ -49,6 +49,8 @@ namespace HandHistories.Objects.Hand
         public decimal? TotalPot { get; set; }
 
         public decimal? Rake { get; set; }
+        public decimal? Jackpot { get; set; }
+        public decimal? Bingo { get; set; }
 
         public override int GetHashCode()
         {

--- a/HandHistories.Objects/Hand/RunItTwice.cs
+++ b/HandHistories.Objects/Hand/RunItTwice.cs
@@ -12,7 +12,7 @@ namespace HandHistories.Objects.Hand
         /// <summary>
         /// The second board
         /// </summary>
-        public BoardCards Board = BoardCards.FromCards(String.Empty);
+        public BoardCards Board; 
 
         /// <summary>
         /// All actions that occur during the second showdown
@@ -87,8 +87,6 @@ namespace HandHistories.Objects.Hand
 
                 if (!w1[i].Equals(w2[i]))
                 {
-                    Console.WriteLine(w1[i].Amount);
-                    Console.WriteLine(w2[i].Amount);
                     return false;
                 }
             }

--- a/HandHistories.Objects/Hand/RunItTwice.cs
+++ b/HandHistories.Objects/Hand/RunItTwice.cs
@@ -12,7 +12,7 @@ namespace HandHistories.Objects.Hand
         /// <summary>
         /// The second board
         /// </summary>
-        public BoardCards Board;
+        public BoardCards Board = BoardCards.FromCards(String.Empty);
 
         /// <summary>
         /// All actions that occur during the second showdown
@@ -20,5 +20,116 @@ namespace HandHistories.Objects.Hand
         public List<HandAction> Actions = new List<HandAction>();
 
         public List<WinningsAction> Winners = new List<WinningsAction>();
+
+
+        public override bool Equals(object obj)
+        {
+            RunItTwice runItTwice = obj as RunItTwice;
+
+            if (runItTwice == null) return false;
+            return CompareBoard(this.Board, runItTwice.Board) && CompareActions(this.Actions, runItTwice.Actions) 
+                && CompareWinners(this.Winners, runItTwice.Winners); 
+        }
+
+
+        public bool CompareBoard(BoardCards b1, BoardCards b2)
+        {
+            if (ReferenceEquals(b1, b2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(b1, null) || ReferenceEquals(b2, null))
+            {
+                return false;
+            }
+            
+            return b1.Equals(b2);
+        }
+
+        public bool CompareActions(List<HandAction> handActions1, List<HandAction> handActions2)
+        {
+            if (ReferenceEquals(handActions1, handActions2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(handActions1, null) || ReferenceEquals(handActions2, null))
+            {
+                return false;
+            }
+
+            if (handActions1.Count != handActions2.Count) { return false; }
+
+            for (int i = 0; i < handActions1.Count; i++)
+            {
+                if (!handActions1[i].Equals(handActions2[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        public bool CompareWinners(List<WinningsAction> w1, List<WinningsAction> w2)
+        {
+            if (ReferenceEquals(w1,w2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(w1, null) || ReferenceEquals(w2, null))
+            {
+                return false;
+            }
+
+            if (w1.Count != w2.Count) { return false; }
+
+            for (int i = 0; i < w1.Count; i++)
+            {
+
+                if (!w1[i].Equals(w2[i]))
+                {
+                    Console.WriteLine(w1[i].Amount);
+                    Console.WriteLine(w2[i].Amount);
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        public static bool operator ==(RunItTwice r1, RunItTwice r2)  
+        { 
+            if (ReferenceEquals(r1, r2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(r1, null) || ReferenceEquals(r2, null))
+            {
+                return false;
+            }
+
+            return r1.Equals(r2); 
+        }
+
+        public static bool operator !=(RunItTwice r1, RunItTwice r2) { return !(r1 == r2); }
+
+        public override int GetHashCode()
+        {
+            int res = 0x2D2816FE;
+            foreach (var item in this.Board)
+            {
+                res = res * 31 + (item == null ? 0 : item.GetHashCode());
+            }
+
+            foreach (var item in this.Winners) 
+            { 
+                res = res * 31 + (item == null ? 0 : item.GetHashCode());
+            }
+
+            foreach (var item in this.Actions) 
+            { 
+                res = res * 31 + (item == null ? 0 : item.GetHashCode());
+            }
+
+            return res;
+        }
     }
 }

--- a/HandHistories.Objects/Players/Player.cs
+++ b/HandHistories.Objects/Players/Player.cs
@@ -38,6 +38,16 @@ namespace HandHistories.Objects.Players
             HoleCards = null;
         }
 
+        public Player(string playerName, 
+                      decimal startingStack,
+                      int seatNumber, HoleCards cards)
+        {
+            PlayerName = playerName;
+            StartingStack = startingStack;
+            SeatNumber = seatNumber;
+            HoleCards = cards;
+        }
+
         public bool hasHoleCards
         {
             get

--- a/HandHistories.Objects/Players/PlayerList.cs
+++ b/HandHistories.Objects/Players/PlayerList.cs
@@ -51,6 +51,34 @@ namespace HandHistories.Objects.Players
             }
         }
 
+        public override bool Equals(object obj)
+        {
+            PlayerList playerList = obj as PlayerList;
+            if (playerList == null) return false;
+
+            if (playerList.Count != this.Count) return false;
+            for (int i = 0; i < playerList.Count; i ++)
+            {
+                if (!playerList[i].Equals(this[i]))  
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int res = 0x2D2816FE;
+            foreach (var item in this)
+            {
+                res = res * 31 + (item == null ? 0 : item.GetHashCode());
+            }
+            return res;
+        }
+
+        public List<Player> GetPlayers() { return _players; }
+
         public void SortList()
         {
             _players = _players.OrderBy(p => p.SeatNumber).ToList();

--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -386,6 +386,18 @@
     <None Update="SampleHandHistories\FullTilt\CashGame\ValidHandTests\ValidHand_1.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\MultiplePosts.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\Regular.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\RushAndCash.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\Straddle.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="SampleHandHistories\IGT\CashGame\ExtraHands\IGT2019Hand.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerFastParserActionTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerFastParserActionTests.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using HandHistories.Objects.Actions;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.GameDescription;
+using HandHistories.Parser.Parsers.FastParser.GGPoker;
+using NUnit.Framework;
+using HandHistories.Parser.UnitTests.Parsers.Base;
+
+namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
+{
+    using Parser = GGPokerFastParserImpl;
+    [TestFixture]
+    class GGPokerFastParserActionTests : HandHistoryParserBaseTests
+    {
+        public GGPokerFastParserActionTests()
+            : base("GGPoker")
+        {
+        }
+
+        protected GGPokerFastParserImpl GetGGPokerFastParser()
+        {
+            return new GGPokerFastParserImpl();
+        }
+
+        [Test]
+        public void ParseRegularActionLine_Raise_Works()
+        {
+            HandAction handAction =
+                GetGGPokerFastParser().ParseRegularActionLine(@"1232423sf: raises $1.1 to $2.1", 9, Street.Preflop);
+
+            Assert.AreEqual(new HandAction("1232423sf", HandActionType.RAISE, 2.1m, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_RaiseAllIn_Works()
+        {
+            HandAction handAction =
+                 GetGGPokerFastParser().ParseRegularActionLine(@"012345678: raises $141.28 to $148.78 and is all-in", 9, Street.Flop);
+
+            Assert.AreEqual(new HandAction("012345678", HandActionType.RAISE, 148.78m, Street.Flop, true), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_BetsAllIn_Works()
+        {
+            HandAction handAction =
+                 GetGGPokerFastParser().ParseRegularActionLine(@"43rfn3x88: bets $3.03 and is all-in", 9, Street.Flop);
+
+            Assert.AreEqual(new HandAction("43rfn3x88", HandActionType.BET, 3.03m, Street.Flop, true), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_CallsAllIn_Works()
+        {
+            HandAction handAction =
+                 GetGGPokerFastParser().ParseRegularActionLine(@"8cd0f41: calls $74.1 and is all-in", 7, Street.Flop);
+
+            Assert.AreEqual(new HandAction("8cd0f41", HandActionType.CALL, 74.1m, Street.Flop, true), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_Calls_Works()
+        {
+            HandAction handAction =
+               GetGGPokerFastParser().ParseRegularActionLine(@"ad0294d4: calls $1.84", 8, Street.Turn);
+
+            Assert.AreEqual(new HandAction("ad0294d4", HandActionType.CALL, 1.84m, Street.Turn), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_Checks_Works()
+        {
+            HandAction handAction =
+               GetGGPokerFastParser().ParseRegularActionLine(@"tr280688: checks", 8, Street.Turn);
+
+            Assert.AreEqual(new HandAction("tr280688", HandActionType.CHECK, 0m, Street.Turn), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_Bets_Works()
+        {
+            HandAction handAction =
+               GetGGPokerFastParser().ParseRegularActionLine(@"MS13ZEN: bets $1.76", 7, Street.River);
+
+            Assert.AreEqual(new HandAction("MS13ZEN", HandActionType.BET, 1.76m, Street.River), handAction);
+        }
+
+        [Test]
+        public void ParsePostingActionLine_SmallBlind_Works()
+        {
+            HandAction handAction = Parser.ParsePostingActionLine(@"1236460a: posts small blind $0.5", 8, false);
+
+            Assert.AreEqual(new HandAction("1236460a", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParsePostingActionLine_BigBlind_Works()
+        {
+            HandAction handAction = Parser.ParsePostingActionLine(@"gaydaddy: posts big blind $1.23", 8, false);
+
+            Assert.AreEqual(new HandAction("gaydaddy", HandActionType.BIG_BLIND, 1.23m, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParsePostingActionLine_Straddle_Works()
+        {
+            HandAction handAction = Parser.ParsePostingActionLine(@"12365032: straddle $2", 8, false);
+
+            Assert.AreEqual(new HandAction("12365032", HandActionType.STRADDLE, 2.0m, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParseRegularActionLine_Folds_Works()
+        {
+            HandAction handAction =
+                GetGGPokerFastParser().ParseRegularActionLine(@"gaydaddy: folds", 8, Street.Preflop);
+
+            Assert.AreEqual(new HandAction("gaydaddy", HandActionType.FOLD, 0, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParseUncalledBetLine_Works()
+        {
+            HandAction handAction =
+                GetGGPokerFastParser().ParseUncalledBetLine(@"Uncalled bet ($6) returned to Hero", Street.Preflop);
+
+            Assert.AreEqual(new HandAction("Hero", HandActionType.UNCALLED_BET, 6, Street.Preflop), handAction);
+        }
+
+        [Test]
+        public void ParseWinnings_Works()
+        {
+            WinningsAction handAction =
+                GetGGPokerFastParser().ParseWinnings(@"a232scs collected $1236.25 from pot");
+
+            Assert.AreEqual(new WinningsAction("a232scs", WinningsActionType.WINS, 1236.25m, 0), handAction);
+        }
+
+        [Test]
+        public void ParseWinnings_WithColon_Works()
+        {
+            WinningsAction handAction =
+                GetGGPokerFastParser().ParseWinnings(@"wo_olly:D collected $0.57 from pot");
+
+            Assert.AreEqual(new WinningsAction("wo_olly:D", WinningsActionType.WINS, 0.57m, 0), handAction);
+        }
+
+        [Test]
+        public void ParseMiscShowdownLine_Shows_Works()
+        {
+            HandAction handAction =
+                GetGGPokerFastParser().ParseMiscShowdownLine(@"RECHUK: shows [Ac Qh] (a full house, Aces full of Queens)", 6);
+
+            Assert.AreEqual(new HandAction("RECHUK", HandActionType.SHOW, 0m, Street.Showdown), handAction);
+        }
+    }
+}

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
@@ -1,0 +1,386 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using HandHistories.Parser.Parsers.FastParser.GGPoker;
+using HandHistories.Parser.UnitTests.Parsers.Base;
+using NUnit.Framework;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.GameDescription;
+using HandHistories.Objects.Hand;
+using HandHistories.Objects.Players;
+using HandHistories.Parser.UnitTests.Utils.Pot;
+using HandHistories.Objects.Actions;
+
+namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
+{
+    using Parser = GGPokerFastParserImpl;
+
+    [TestFixture]
+    class GGPokerHandSummaryParserExtraTests: HandHistoryParserBaseTests
+    {
+        public GGPokerHandSummaryParserExtraTests() : base("GGPoker")
+        {
+
+        }
+
+        private HandHistorySummary TestFullHandHistorySummary(HandHistorySummary expectedSummary, string fileName)
+        {
+            string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "GeneralHands", fileName);
+
+            HandHistorySummary actualSummary = GetSummmaryParser().ParseFullHandSummary(handText, true);
+
+            Assert.AreEqual(expectedSummary.GameDescription, actualSummary.GameDescription);
+            Assert.AreEqual(expectedSummary.DealerButtonPosition, actualSummary.DealerButtonPosition);
+            Assert.AreEqual(expectedSummary.DateOfHandUtc, actualSummary.DateOfHandUtc);
+            Assert.AreEqual(expectedSummary.HandId, actualSummary.HandId);
+            Assert.AreEqual(expectedSummary.NumPlayersSeated, actualSummary.NumPlayersSeated);
+            Assert.AreEqual(expectedSummary.TableName, actualSummary.TableName);
+            Assert.AreEqual(expectedSummary.TotalPot, actualSummary.TotalPot);
+            Assert.AreEqual(expectedSummary.Rake, actualSummary.Rake);
+            Assert.AreEqual(expectedSummary.Jackpot, actualSummary.Jackpot);
+            Assert.AreEqual(expectedSummary.Bingo, actualSummary.Bingo);
+
+            return actualSummary;
+        }
+
+        private HandHistory TestHandHistory(HandHistory expectedHandHistory, string fileName)
+        {
+            string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "GeneralHands", fileName);
+
+            HandHistory handHistory = GetParser().ParseFullHandHistory(handText, true);
+           
+            Assert.IsTrue(expectedHandHistory.CommunityCards.Equals(handHistory.CommunityCards));
+            Assert.IsTrue(expectedHandHistory.Players.Equals(handHistory.Players));
+            Assert.AreEqual(expectedHandHistory.Hero, handHistory.Hero);
+            Assert.AreEqual(expectedHandHistory.NumPlayersActive, handHistory.NumPlayersActive);
+            Assert.AreEqual(expectedHandHistory.RunItMultipleTimes.Length, handHistory.RunItMultipleTimes.Length);
+
+            Assert.IsTrue(expectedHandHistory.RunItMultipleTimes[0].Equals(handHistory.RunItMultipleTimes[0]));
+            Assert.IsTrue(expectedHandHistory.RunItMultipleTimes[1].Equals(handHistory.RunItMultipleTimes[1]));
+            Assert.IsTrue(expectedHandHistory.RunItMultipleTimes[2].Equals(handHistory.RunItMultipleTimes[2]));
+
+            //Assert.IsTrue(expectedHandHistory.HandActions.Equals(handHistory.HandActions));
+            TestWinners(expectedHandHistory.Winners, handHistory.Winners);
+            TestActions(expectedHandHistory.HandActions, handHistory.HandActions);
+
+            return handHistory;
+        }
+
+        private void TestWinners(List<WinningsAction> expectedWinningsActions, List<WinningsAction> winningsActions) 
+        { 
+            Assert.AreEqual(expectedWinningsActions.Count, winningsActions.Count);
+            for (int i = 0; i < expectedWinningsActions.Count; i++) 
+            {
+                Assert.AreEqual(expectedWinningsActions[i], winningsActions[i]);
+            }
+        }
+
+        private void TestActions(List<HandAction> expectedHandActions, List<HandAction> handActions)
+        {
+            Assert.AreEqual(handActions.Count, expectedHandActions.Count);
+            for (int i = 0; i < expectedHandActions.Count; i++)
+            {
+                Assert.AreEqual(expectedHandActions[i], handActions[i]);
+            }
+        }
+
+        [Test]
+        public void ZoomHand()
+        {
+            HandHistorySummary expectedSummary = new HandHistorySummary()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(0.05m, 0.1m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.GGPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Zoom)
+                },
+                DateOfHandUtc = new DateTime(2018, 3, 30, 3, 44, 33),
+                DealerButtonPosition = 1,
+                HandId = HandID.From(2345481320),
+                NumPlayersSeated = 6,
+                TableName = "RushAndCash143219",
+                TotalPot = 1,
+                Rake = 0.05m,
+                Jackpot = 0,
+                Bingo = 0
+            };
+
+            HandHistory expectedHandHistory = new HandHistory()
+            {
+                CommunityCards = BoardCards.FromCards("5d7hks"),
+                Players = new PlayerList(new List<Player>
+                {
+                    new Player("Hero", 22, 3, HoleCards.FromCards("Ac3d")),
+                    new Player("2734abdf", 22.17m, 2),
+                    new Player("1234gsaa", 14.67m, 1),
+                    new Player("788bnr4e", 12.43m, 4),
+                    new Player("gm27b4sg", 8.9m, 5),
+                    new Player("153ddcg3", 7.83m, 6),
+                }),
+                Hero = new Player("Hero", 22, 3, HoleCards.FromCards("3DAC")),
+                RunItMultipleTimes = new RunItTwice[]
+                {
+                    new RunItTwice
+                    {
+                        Board = BoardCards.FromCards("ks7h5d"),
+                        Actions = new List<HandAction> { },
+                        Winners = new List<WinningsAction>
+                        {
+                            new WinningsAction("2734abdf", WinningsActionType.WINS, 0.95m, 0)
+                        }
+                    },
+                    new RunItTwice {},
+                    new RunItTwice {}
+                },
+                Winners = new List<WinningsAction>() { new WinningsAction("2734abdf", WinningsActionType.WINS, 0.95m, 0)},
+                HandActions = new List<HandAction>() { 
+                    new HandAction("2734abdf", HandActionType.SMALL_BLIND, -0.05m, Street.Preflop),
+                    new HandAction("Hero", HandActionType.BIG_BLIND, -0.1m, Street.Preflop),
+                    new HandAction("788bnr4e", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("gm27b4sg", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("153ddcg3", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("1234gsaa", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("2734abdf", HandActionType.RAISE, 0.25m, Street.Preflop),
+                    new HandAction("Hero", HandActionType.CALL, 0.2m, Street.Preflop),
+                    new HandAction("2734abdf", HandActionType.CHECK, 0, Street.Flop), 
+                    new HandAction("Hero", HandActionType.BET, 0.2m, Street.Flop),
+                    new HandAction("2734abdf", HandActionType.RAISE, 0.7m, Street.Flop),
+                    new HandAction("Hero", HandActionType.FOLD, 0, Street.Flop),
+                    new HandAction("2734abdf", HandActionType.UNCALLED_BET, 0.5m, Street.Flop),
+                }
+            };
+            TestFullHandHistorySummary(expectedSummary, "RushAndCash");
+            TestHandHistory(expectedHandHistory, "RushAndCash");
+        }
+
+
+        [Test]
+        public void TestRegularHand()
+        {
+            HandHistorySummary expectedSummary = new HandHistorySummary()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(0.5m, 1m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.GGPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Regular)
+                },
+                DateOfHandUtc = new DateTime(2017, 11, 12, 11, 43, 27),
+                DealerButtonPosition = 2,
+                HandId = HandID.From(23847510),
+                NumPlayersSeated = 5,
+                TableName = "NLHGold11",
+                TotalPot = 2,
+                Rake = 0,
+                Jackpot = 0,
+                Bingo = 0
+            };
+
+            HandHistory expectedHandHistory = new HandHistory()
+            {
+                CommunityCards = BoardCards.FromCards(String.Empty),
+                Players = new PlayerList(new List<Player>
+                {
+                    new Player("79adcegg", 173.04m, 1),
+                    new Player("853aak6d", 100m, 2),
+                    new Player("ac12334d", 190.65m, 4),
+                    new Player("1234gsaa", 85.59m, 5),
+                    new Player("Hero", 300.5m, 6, HoleCards.FromCards("5h2c")),
+                }),
+                Hero = new Player("Hero", 300.5m, 6, HoleCards.FromCards("2c5h")),
+                RunItMultipleTimes = new RunItTwice[]
+                {
+                    new RunItTwice
+                    {
+                        Board = BoardCards.FromCards(String.Empty),
+                        Actions = new List<HandAction> { },
+                        Winners = new List<WinningsAction>
+                        {
+                            new WinningsAction("ac12334d", WinningsActionType.WINS, 2m, 0)
+                        }
+                    },
+                    new RunItTwice {},
+                    new RunItTwice {}
+                },
+                Winners = new List<WinningsAction>() { new WinningsAction("ac12334d", WinningsActionType.WINS, 2m, 0)},
+                HandActions = new List<HandAction>() { 
+                    new HandAction("ac12334d", HandActionType.SMALL_BLIND, -0.5m, Street.Preflop),
+                    new HandAction("1234gsaa", HandActionType.BIG_BLIND, -1, Street.Preflop),
+                    new HandAction("Hero", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("79adcegg", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("853aak6d", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("ac12334d", HandActionType.RAISE, 3m, Street.Preflop),
+                    new HandAction("1234gsaa", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("ac12334d", HandActionType.UNCALLED_BET, 2.5m, Street.Preflop),
+                }
+            };
+            TestFullHandHistorySummary(expectedSummary, "Regular");
+            TestHandHistory(expectedHandHistory, "Regular");
+        }
+
+        [Test]
+        public void Straddle()
+        {
+            HandHistorySummary expectedSummary = new HandHistorySummary()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(0.5m, 1m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.GGPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Regular)
+                },
+                DateOfHandUtc = new DateTime(2018, 12, 11, 16, 21, 51),
+                DealerButtonPosition = 6,
+                HandId = HandID.From(582731),
+                NumPlayersSeated = 6,
+                TableName = "NLHGold7",
+                TotalPot = 28.9m,
+                Rake = 1.44m,
+                Jackpot = 0,
+                Bingo = 0
+            };
+
+            HandHistory expectedHandHistory = new HandHistory()
+            {
+                CommunityCards = BoardCards.FromCards("ThJh7dAc"),
+                Players = new PlayerList(new List<Player>
+                {
+                    new Player("xnvdam1", 103.5m, 1),
+                    new Player("3fak3jfj2", 106.89m, 2),
+                    new Player("Hero", 100.23m, 3, HoleCards.FromCards("TcKs")),
+                    new Player("62dfdfaf", 105.63m, 4),
+                    new Player("fdafscsa", 100, 5),
+                    new Player("123dca2d", 133.34m, 6),
+                }),
+                Hero = new Player("Hero", 100.23m, 3, HoleCards.FromCards("KsTc")),
+                RunItMultipleTimes = new RunItTwice[]
+                {
+                    new RunItTwice
+                    {
+                        Board = BoardCards.FromCards("ThJh7dAc"),
+                        Actions = new List<HandAction> { },
+                        Winners = new List<WinningsAction>
+                        {
+                            new WinningsAction("xnvdam1", WinningsActionType.WINS, 27.46m, 0)
+                        }
+                    },
+                    new RunItTwice {},
+                    new RunItTwice {}
+                },
+                Winners = new List<WinningsAction>() { new WinningsAction("xnvdam1", WinningsActionType.WINS, 27.46m, 0)},
+                HandActions = new List<HandAction>() { 
+                    new HandAction("xnvdam1", HandActionType.SMALL_BLIND, -0.5m, Street.Preflop),
+                    new HandAction("3fak3jfj2", HandActionType.BIG_BLIND, -1, Street.Preflop),
+                    new HandAction("62dfdfaf", HandActionType.STRADDLE, -2, Street.Preflop),
+                    new HandAction("fdafscsa", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("123dca2d", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("xnvdam1", HandActionType.RAISE, 6.50m, Street.Preflop),
+                    new HandAction("3fak3jfj2", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("Hero", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("62dfdfaf", HandActionType.CALL, 5m, Street.Preflop),
+                    new HandAction("xnvdam1", HandActionType.BET, 6.95m, Street.Flop),
+                    new HandAction("62dfdfaf", HandActionType.CALL, 6.95m, Street.Flop),
+                    new HandAction("xnvdam1", HandActionType.BET, 22.68m, Street.Turn), 
+                    new HandAction("62dfdfaf", HandActionType.FOLD, 0, Street.Turn),
+                    new HandAction("xnvdam1", HandActionType.UNCALLED_BET, 22.68m, Street.Turn), 
+                }
+            };
+            TestFullHandHistorySummary(expectedSummary, "Straddle");
+            TestHandHistory(expectedHandHistory, "Straddle");
+        }
+
+        [Test]
+        public void MultiplePosts()
+        {
+            HandHistorySummary expectedSummary = new HandHistorySummary()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(0.25m, 0.5m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.GGPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Regular)
+                },
+                DateOfHandUtc = new DateTime(2017, 11, 30, 19, 22, 11),
+                DealerButtonPosition = 4,
+                HandId = HandID.From(11358),
+                NumPlayersSeated = 5,
+                TableName = "NLHGold12",
+                TotalPot = 13.3m,
+                Rake = 1.42m,
+                Jackpot = 0,
+                Bingo = 0
+            };
+
+            HandHistory expectedHandHistory = new HandHistory()
+            {
+                CommunityCards = BoardCards.FromCards("Ts7h5d2hKc"),
+                Players = new PlayerList(new List<Player>
+                {
+                    new Player("Hero", 25.31m, 1, HoleCards.FromCards("7d2c")),
+                    new Player("123dca2d", 40m, 2),
+                    new Player("casf123d", 58.14m, 4),
+                    new Player("facdasfwc", 29.61m, 5),
+                    new Player("fadfvasf", 42.3m, 6),
+                }),
+                Hero = new Player("Hero", 25.31m, 1, HoleCards.FromCards("7d2c")),
+                RunItMultipleTimes = new RunItTwice[]
+                {
+                    new RunItTwice
+                    {
+                        Board = BoardCards.FromCards("Ts7h5d2hKc"),
+                        Actions = new List<HandAction> { },
+                        Winners = new List<WinningsAction>
+                        {
+                            new WinningsAction("123dca2d", WinningsActionType.WINS, 11.88m, 0)
+                        }
+                    },
+                    new RunItTwice {},
+                    new RunItTwice {}
+                },
+                Winners = new List<WinningsAction>() { new WinningsAction("123dca2d", WinningsActionType.WINS, 11.88m, 0) },
+                HandActions = new List<HandAction>() {
+                    new HandAction("facdasfwc", HandActionType.SMALL_BLIND, -0.25m, Street.Preflop),
+                    new HandAction("fadfvasf", HandActionType.BIG_BLIND, -0.5m, Street.Preflop),
+                    new HandAction("123dca2d", HandActionType.POSTS, -0.5m, Street.Preflop),
+                    new HandAction("Hero", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("123dca2d", HandActionType.CHECK, 0, Street.Preflop),
+                    new HandAction("casf123d", HandActionType.CALL, 0.5m, Street.Preflop),
+                    new HandAction("facdasfwc", HandActionType.CALL, 0.25m, Street.Preflop),
+                    new HandAction("fadfvasf", HandActionType.CHECK, 0, Street.Preflop),
+                    new HandAction("facdasfwc", HandActionType.CHECK, 0, Street.Flop),
+                    new HandAction("fadfvasf", HandActionType.CHECK, 0, Street.Flop),
+                    new HandAction("123dca2d", HandActionType.BET, 1m, Street.Flop),
+                    new HandAction("casf123d", HandActionType.FOLD, 0m, Street.Flop),
+                    new HandAction("facdasfwc", HandActionType.CALL, 1m, Street.Flop),
+                    new HandAction("fadfvasf", HandActionType.CALL, 1m, Street.Flop),
+                    new HandAction("facdasfwc", HandActionType.CHECK, 0, Street.Turn),
+                    new HandAction("fadfvasf", HandActionType.CHECK, 0, Street.Turn),
+                    new HandAction("123dca2d", HandActionType.BET, 3.1m, Street.Turn),
+                    new HandAction("facdasfwc", HandActionType.CALL, 3.1m, Street.Turn),
+                    new HandAction("fadfvasf", HandActionType.CALL, 3.1m, Street.Turn),
+                    new HandAction("facdasfwc", HandActionType.CHECK, 0, Street.River),
+                    new HandAction("fadfvasf", HandActionType.CHECK, 0, Street.River), 
+                    new HandAction("123dca2d", HandActionType.BET, 8.2m, Street.River),
+                    new HandAction("facdasfwc", HandActionType.FOLD, 0m, Street.River),
+                    new HandAction("fadfvasf", HandActionType.FOLD, 0m, Street.River),
+                    new HandAction("123dca2d", HandActionType.UNCALLED_BET, 8.2m, Street.River),
+                }
+            };
+            TestFullHandHistorySummary(expectedSummary, "MultiplePosts");
+            TestHandHistory(expectedHandHistory, "MultiplePosts");
+        }
+    }
+}

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
@@ -48,8 +48,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
             string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "GeneralHands", fileName);
 
             HandHistory handHistory = GetParser().ParseFullHandHistory(handText, true);
-           
-            Assert.IsTrue(expectedHandHistory.CommunityCards.Equals(handHistory.CommunityCards));
+            Assert.IsTrue(expectedHandHistory.CommunityCards == handHistory.CommunityCards);
             Assert.IsTrue(expectedHandHistory.Players.Equals(handHistory.Players));
             Assert.AreEqual(expectedHandHistory.Hero, handHistory.Hero);
             Assert.AreEqual(expectedHandHistory.NumPlayersActive, handHistory.NumPlayersActive);
@@ -59,7 +58,6 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
             Assert.IsTrue(expectedHandHistory.RunItMultipleTimes[1].Equals(handHistory.RunItMultipleTimes[1]));
             Assert.IsTrue(expectedHandHistory.RunItMultipleTimes[2].Equals(handHistory.RunItMultipleTimes[2]));
 
-            //Assert.IsTrue(expectedHandHistory.HandActions.Equals(handHistory.HandActions));
             TestWinners(expectedHandHistory.Winners, handHistory.Winners);
             TestActions(expectedHandHistory.HandActions, handHistory.HandActions);
 
@@ -185,7 +183,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
 
             HandHistory expectedHandHistory = new HandHistory()
             {
-                CommunityCards = BoardCards.FromCards(String.Empty),
+                CommunityCards = null,
                 Players = new PlayerList(new List<Player>
                 {
                     new Player("79adcegg", 173.04m, 1),
@@ -199,7 +197,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
                 {
                     new RunItTwice
                     {
-                        Board = BoardCards.FromCards(String.Empty),
+                        Board = null,
                         Actions = new List<HandAction> { },
                         Winners = new List<WinningsAction>
                         {

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
@@ -183,7 +183,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
 
             HandHistory expectedHandHistory = new HandHistory()
             {
-                CommunityCards = null,
+                CommunityCards = BoardCards.ForPreflop(),
                 Players = new PlayerList(new List<Player>
                 {
                     new Player("79adcegg", 173.04m, 1),

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/MultiplePosts.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/MultiplePosts.txt
@@ -1,0 +1,51 @@
+Poker Hand #HD11358: Hold'em No Limit  ($0.25/$0.5) - 2017/11/30 19:22:11
+Table 'NLHGold12' 6-max Seat #4 is the button
+Seat 1: Hero ($25.31 in chips)
+Seat 2: 123dca2d ($40 in chips)
+Seat 4: casf123d ($58.14 in chips)
+Seat 5: facdasfwc ($29.61 in chips)
+Seat 6: fadfvasf ($42.3 in chips)
+facdasfwc: posts small blind $0.25
+fadfvasf: posts big blind $0.5
+123dca2d: posts big blind $0.5
+*** HOLE CARDS ***
+Dealt to Hero [7d 2c]
+Dealt to 123dca2d
+Dealt to casf123d
+Dealt to facdasfwc
+Dealt to fadfvasf
+Hero: folds
+123dca2d: checks
+casf123d: calls $0.5
+facdasfwc: calls $0.25
+fadfvasf: checks
+*** FLOP *** [Ts 7h 5d]
+facdasfwc: checks
+fadfvasf: checks
+123dca2d: bets $1
+casf123d: folds
+facdasfwc: calls $1
+fadfvasf: calls $1
+*** TURN *** [Ts 7h 5d] [2h]
+facdasfwc: checks
+fadfvasf: checks
+123dca2d: bets $3.1
+facdasfwc: calls $3.1
+fadfvasf: calls $3.1
+*** RIVER *** [Ts 7h 5d 2h] [Kc]
+facdasfwc: checks
+fadfvasf: checks
+123dca2d: bets $8.2
+facdasfwc: folds
+fadfvasf: folds
+Uncalled bet ($8.2) returned to 123dca2d
+*** SHOWDOWN ***
+123dca2d collected $11.88 from pot
+*** SUMMARY ***
+Total pot $13.3 | Rake $1.42 | Jackpot $0 | Bingo $0
+Board [Ts 7h 5d 2h Kc]
+Seat 1: Hero folded before Flop (didn't bet)
+Seat 2: 123dca2d won ($11.88)
+Seat 4: casf123d (button) folded on the Flop
+Seat 5: facdasfwc (small blind) folded on the River
+Seat 6: fadfvasf (big blind) folded on the River

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/Regular.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/Regular.txt
@@ -1,0 +1,30 @@
+Poker Hand #HD23847510: Hold'em No Limit  ($0.5/$1) - 2017/11/12 11:43:27
+Table 'NLHGold11' 6-max Seat #2 is the button
+Seat 1: 79adcegg ($173.04 in chips)
+Seat 2: 853aak6d ($100 in chips)
+Seat 4: ac12334d ($190.65 in chips)
+Seat 5: 1234gsaa ($85.59 in chips)
+Seat 6: Hero ($300.5 in chips)
+ac12334d: posts small blind $0.5
+1234gsaa: posts big blind $1
+*** HOLE CARDS ***
+Dealt to 79adcegg 
+Dealt to 853aak6d 
+Dealt to ac12334d 
+Dealt to 1234gsaa 
+Dealt to Hero [5h 2c]
+Hero: folds
+79adcegg: folds
+853aak6d: folds
+ac12334d: raises $2.5 to $3.5
+1234gsaa: folds
+Uncalled bet ($2.5) returned to ac12334d
+*** SHOWDOWN ***
+ac12334d collected $2 from pot
+*** SUMMARY ***
+Total pot $2 | Rake $0 | Jackpot $0 | Bingo $0
+Seat 1: 79adcegg folded before Flop (didn't bet)
+Seat 2: 853aak6d (button) folded before Flop (didn't bet)
+Seat 4: ac12334d (small blind) collected ($2)
+Seat 5: 1234gsaa (big blind) folded before Flop
+Seat 6: Hero folded before Flop (didn't bet)

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/RushAndCash.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/RushAndCash.txt
@@ -1,0 +1,40 @@
+Poker Hand #RC2345481320: Hold'em No Limit  ($0.05/$0.1) - 2018/03/30 03:44:33
+Table 'RushAndCash143219' 6-max Seat #1 is the button
+Seat 1: 1234gsaa ($14.67 in chips)
+Seat 2: 2734abdf ($22.17 in chips)
+Seat 3: Hero ($22 in chips)
+Seat 4: 788bnr4e ($12.43 in chips)
+Seat 5: gm27b4sg ($8.9 in chips)
+Seat 6: 153ddcg3 ($7.83 in chips)
+2734abdf: posts small blind $0.05
+Hero: posts big blind $0.1
+*** HOLE CARDS ***
+Dealt to 1234gsaa
+Dealt to 2734abdf
+Dealt to Hero [3d Ac]
+Dealt to 788bnr4e
+Dealt to gm27b4sg
+Dealt to 153ddcg3
+788bnr4e: folds
+gm27b4sg: folds
+153ddcg3: folds
+1234gsaa: folds
+2734abdf: raises $0.2 to $0.3
+Hero: calls $0.2
+*** FLOP *** [Ks 7h 5d]
+2734abdf: checks
+Hero: bets $0.2
+2734abdf: raises $0.5 to $0.7
+Hero: folds
+Uncalled bet ($0.5) returned to 2734abdf
+*** SHOWDOWN ***
+2734abdf collected $0.95 from pot
+*** SUMMARY ***
+Total pot $1 | Rake $0.05 | Jackpot $0 | Bingo $0
+Board [Ks 7h 5d]
+Seat 1: 1234gsaa (button) folded before Flop (didn't bet)
+Seat 2: 2734abdf (small blind) won ($0.95)
+Seat 3: Hero (big blind) folded on the Flop
+Seat 4: 788bnr4e folded before Flop (didn't bet)
+Seat 5: gm27b4sg folded before Flop (didn't bet)
+Seat 6: 153ddcg3 folded before Flop (didn't bet)

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/Straddle.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/Straddle.txt
@@ -1,0 +1,42 @@
+Poker Hand #HD582731: Hold'em No Limit  ($0.5/$1) - 2018/12/11 16:21:51
+Table 'NLHGold7' 6-max Seat #6 is the button
+Seat 1: xnvdam1 ($103.5 in chips)
+Seat 2: 3fak3jfj2 ($106.89 in chips)
+Seat 3: Hero ($100.23 in chips)
+Seat 4: 62dfdfaf ($105.63 in chips)
+Seat 5: fdafscsa ($100 in chips)
+Seat 6: 123dca2d ($133.34 in chips)
+xnvdam1: posts small blind $0.5
+3fak3jfj2: posts big blind $1
+62dfdfaf: straddle $2
+*** HOLE CARDS ***
+Dealt to xnvdam1
+Dealt to 3fak3jfj2
+Dealt to Hero [Tc Ks]
+Dealt to 62dfdfaf
+Dealt to fdafscsa
+Dealt to 123dca2d
+fdafscsa: folds
+123dca2d: folds
+xnvdam1: raises $5 to $7
+3fak3jfj2: folds
+Hero: folds
+62dfdfaf: calls $5
+*** FLOP *** [Th Jh 7d]
+xnvdam1: bets $6.95
+62dfdfaf: calls $6.95
+*** TURN *** [Th Jh 7d] [Ac]
+xnvdam1: bets $22.68
+62dfdfaf: folds
+Uncalled bet ($22.68) returned to xnvdam1
+*** SHOWDOWN ***
+xnvdam1 collected $27.46 from pot
+*** SUMMARY ***
+Total pot $28.9 | Rake $1.44 | Jackpot $0 | Bingo $0
+Board [Th Jh 7d Ac]
+Seat 1: xnvdam1 (small blind) won ($27.46)
+Seat 2: 3fak3jfj2 (big blind) folded before Flop
+Seat 3: Hero folded before Flop (didn't bet)
+Seat 4: 62dfdfaf folded on the Turn
+Seat 5: fdafscsa folded before Flop (didn't bet)
+Seat 6: 123dca2d (button) folded before Flop (didn't bet)

--- a/HandHistories.Parser/Parsers/Factory/HandHistoryParserFactoryImpl.cs
+++ b/HandHistories.Parser/Parsers/Factory/HandHistoryParserFactoryImpl.cs
@@ -17,6 +17,7 @@ using HandHistories.Parser.Parsers.JSONParser.IGT;
 using HandHistories.Parser.Parsers.LineCategoryParser.WinningPokerV2;
 using HandHistories.Parser.Parsers.LineCategoryParser.PartyPoker;
 using System.Text.RegularExpressions;
+using HandHistories.Parser.Parsers.FastParser.GGPoker;
 
 namespace HandHistories.Parser.Parsers.Factory
 {
@@ -80,6 +81,8 @@ namespace HandHistories.Parser.Parsers.Factory
                 case SiteName.AsianPokerClubs:
                     var splitRegex = new Regex("PokerMaster Hand #", RegexOptions.Compiled);
                     return new PokerStarsFastParserImpl(SiteName.AsianPokerClubs, splitRegex);
+                case SiteName.GGPoker:
+                    return new GGPokerFastParserImpl();
                 default:
                     throw new NotImplementedException("GetHandHistorySummaryParser: No full regex parser for " + siteName);
             }
@@ -138,6 +141,8 @@ namespace HandHistories.Parser.Parsers.Factory
                 case SiteName.AsianPokerClubs:
                     var splitRegex = new Regex("PokerMaster Hand #", RegexOptions.Compiled);
                     return new PokerStarsFastParserImpl(SiteName.AsianPokerClubs, splitRegex);
+                case SiteName.GGPoker:
+                    return new GGPokerFastParserImpl();
                 default:
                     throw new NotImplementedException("GetHandHistorySummaryParser: No summary regex parser for " + siteName);
             }

--- a/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
@@ -180,7 +180,14 @@ namespace HandHistories.Parser.Parsers.FastParser.Base
 
                 if (SupportRunItTwice)
                 {
-                    handHistory.RunItTwiceData = ParseRunItTwice(handLines);
+                    if (SiteName.Equals(SiteName.GGPoker))
+                    {
+                        handHistory.RunItMultipleTimes = ParseMultiplerRuns(handLines);
+                    }
+                    else 
+                    {
+                        handHistory.RunItTwiceData = ParseRunItTwice(handLines);
+                    }
                 }
 
                 List<WinningsAction> winners;
@@ -597,6 +604,11 @@ namespace HandHistories.Parser.Parsers.FastParser.Base
         protected abstract BoardCards ParseCommunityCards(string[] handLines);
 
         public virtual RunItTwice ParseRunItTwice(string[] handLines)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual RunItTwice[] ParseMultiplerRuns(string[] handLines)
         {
             throw new NotImplementedException();
         }

--- a/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
@@ -40,9 +40,7 @@ namespace HandHistories.Parser.Parsers.FastParser.GGPoker
 
         private readonly Regex _handSplitRegex;
 
-        private readonly Regex _handIdRegex;
-
-        private readonly String _summarySeperator;
+        private readonly String _summarySeperator = " | ";
 
         public GGPokerFastParserImpl()
         {
@@ -54,8 +52,6 @@ namespace HandHistories.Parser.Parsers.FastParser.GGPoker
                 CurrencySymbol = "$"
             };
             _handSplitRegex = new Regex("Poker Hand #", RegexOptions.Compiled);
-            _summarySeperator = " | ";
-            _handIdRegex = new Regex("RC#[0-9]+|HD#[0-9]+", RegexOptions.Compiled);
         }
 
         public override IEnumerable<string> SplitUpMultipleHands(string rawHandHistories)
@@ -543,7 +539,7 @@ namespace HandHistories.Parser.Parsers.FastParser.GGPoker
                     return ParseBoard(line);
                 }
             }
-            return BoardCards.FromCards(String.Empty);
+            return null;
         }
 
         public override RunItTwice[] ParseMultiplerRuns(string[] handLines)

--- a/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
@@ -1,0 +1,897 @@
+﻿using HandHistories.Parser.Parsers.Base;
+using HandHistories.Parser.Parsers.FastParser.Base;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using HandHistories.Objects;
+using HandHistories.Objects.Actions;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.GameDescription;
+using HandHistories.Objects.Hand;
+using HandHistories.Objects.Players;
+using HandHistories.Parser.Parsers.Exceptions;
+using HandHistories.Parser.Utils.Extensions;
+using HandHistories.Parser.Utils.FastParsing;
+using HandHistories.Parser.Utils.Uncalled;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Net.NetworkInformation;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Net;
+
+namespace HandHistories.Parser.Parsers.FastParser.GGPoker
+{
+
+    public partial class GGPokerFastParserImpl : HandHistoryParserFastImpl, IThreeStateParser
+    {
+        static readonly TimeZoneInfo PokerStarsTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+
+        public override bool RequiresAdjustedRaiseSizes => true;
+
+        public override bool SupportRunItTwice => true;
+
+        public override bool RequiresActionSorting => true;
+
+        public override SiteName SiteName => SiteName.GGPoker;
+
+        private readonly NumberFormatInfo _numberFormatInfo;
+
+        private readonly Regex _handSplitRegex;
+
+        private readonly Regex _handIdRegex;
+
+        private readonly String _summarySeperator;
+
+        public GGPokerFastParserImpl()
+        {
+            _numberFormatInfo = new NumberFormatInfo
+            {
+                NegativeSign = "-",
+                CurrencyDecimalSeparator = ".",
+                CurrencyGroupSeparator = ",",
+                CurrencySymbol = "$"
+            };
+            _handSplitRegex = new Regex("Poker Hand #", RegexOptions.Compiled);
+            _summarySeperator = " | ";
+            _handIdRegex = new Regex("RC#[0-9]+|HD#[0-9]+", RegexOptions.Compiled);
+        }
+
+        public override IEnumerable<string> SplitUpMultipleHands(string rawHandHistories)
+        {
+            return Utils.HandSplitter.RegexHandSplitter.Split(rawHandHistories, _handSplitRegex);
+        }
+
+        protected override int ParseDealerPosition(string[] handLines)
+        {
+            // Expect the 2nd line to look like the below two, one for regular table, one for rush&cash:
+            // Table 'RushAndCash143219' 6-max Seat #1 is the button
+
+            // or
+
+            // Table 'NLHSilver9' 6-max Seat #2 is the button
+            string line = handLines[1];
+            return FastInt.Parse(line.Substring(line.Length-15,1));
+        }
+
+        protected override DateTime ParseDateUtc(string[] handLines)
+        {
+            // Expect the first line to look like this:
+            // Poker Hand #RC2345481320: Hold'em No Limit  ($0.05/$0.1) - 2018/03/31 14:43:23
+
+            // or
+
+            // Poker Hand #HD138495: Hold'em No Limit  ($0.5/$1) - 2019/10/12 01:43:27
+            string line = handLines[0];
+            return DateTime.ParseExact(line.Substring(line.Length - 19), "yyyy/MM/dd HH:mm:ss", new CultureInfo("en-US"));
+        }
+
+        protected override void ParseExtraHandInformation(string[] handLines, HandHistorySummary handHistorySummary)
+        {
+            if (handHistorySummary.Cancelled) { return; }
+
+            for (int i = handLines.Length - 1; i >= 0; i--)
+            {
+                string line = handLines[i];
+
+                // *** SUMMARY ***
+                if (line.StartsWithFast("*** SUMMARY"))
+                {
+                    break;
+                }
+
+                // Total pot $1 | Rake $0.05 | Jackpot $0 | Bingo $0
+                if (line.StartsWithFast("Total pot"))
+                {
+                    string[] breakdown = line.Split(_summarySeperator);
+                    handHistorySummary.TotalPot = breakdown[0].Substring(10).ParseAmountWS();
+                    handHistorySummary.Rake = breakdown[1].Substring(5).ParseAmountWS();
+                    handHistorySummary.Jackpot = breakdown[2].Substring(8).ParseAmountWS();
+                    handHistorySummary.Bingo = breakdown[3].Substring(6).ParseAmountWS();
+                }
+            }
+        }
+
+        public int ParseBlindActions(string[] handLines, List<HandAction> handActions, int firstActionIndex)
+        {
+            var bigBlind = false;
+
+            for (int i = 2; i < handLines.Length; i++)
+            {
+                var line = handLines[i];
+
+                switch (line.Last())
+                {
+                    //*** HOLE CARDS ***
+                    case '*':
+                        return i + 1;
+                    //*** FLOP *** [6d 7c 6h]
+                    //*** TURN *** [6d 7c 6h] [2s]
+                    //*** RIVER *** [6d 7c 6h 2s] [Qc]
+                    case ']':
+                        throw new HandActionException(string.Join(Environment.NewLine, handLines), "Unexpected Line: " + line);
+
+                    // Seat 1: 12345678 ($100 in chips)
+                    case ')':
+                        continue;
+
+                    default:
+                        break;
+                }
+
+
+                int colonIndex = line.LastIndexOf(':');
+
+                if (colonIndex != -1)
+                {
+                    var action = ParsePostingActionLine(line, colonIndex, bigBlind);
+                    bigBlind = action.HandActionType == HandActionType.BIG_BLIND;
+                    handActions.Add(action);
+                }
+            }
+            throw new HandActionException(string.Join(Environment.NewLine, handLines), "No end of posting actions");
+        }
+
+        public static HandAction ParsePostingActionLine(string actionLine, int colonIndex, bool bigBlindPosted)
+        {
+            string playerName = actionLine.Substring(0, colonIndex);
+            bool isAllIn = false;
+
+            // Expect lines to look like:
+            // ac12334d: posts small blind $0.5
+            // ac12334d: posts big blind $1
+            // 62dfdfaf: straddle $2
+            char identifierChar = actionLine[colonIndex + 8];
+
+            // xyz: posts big blind $1 and is all-in
+            if (actionLine.EndsWithFast("is all-in"))
+            {
+                isAllIn = true;
+                actionLine = actionLine.Substring(0, actionLine.Length - 14);
+            }
+
+            int firstDigitIndex;
+            HandActionType handActionType;
+
+            switch (identifierChar)
+            {
+                // ac12334d: posts small blind $0.5
+                case 's':
+                    firstDigitIndex = colonIndex + 20;
+                    handActionType = HandActionType.SMALL_BLIND;
+                    break;
+
+                // ac12334d: posts big blind $0.5
+                case 'b':
+                    firstDigitIndex = colonIndex + 18;
+                    handActionType = bigBlindPosted ? HandActionType.POSTS : HandActionType.BIG_BLIND;
+                    break;
+
+                // xyz: straddle $2
+                case 'l':
+                    firstDigitIndex = colonIndex + 11;
+                    handActionType = HandActionType.STRADDLE;
+                    break;
+
+                default:
+                    throw new HandActionException(actionLine, "ParsePostingActionLine: Unregonized line " + actionLine);
+            }
+
+            decimal amount = actionLine.Substring(firstDigitIndex).ParseAmount();
+            return new HandAction(playerName, handActionType, amount, Street.Preflop, isAllIn);
+        }
+
+        public int ParseGameActions(string[] handLines, List<HandAction> handActions, List<WinningsAction> winners, int firstActionIndex, out Street street)
+        {
+            street = Street.Preflop;
+
+            for (int lineNumber = firstActionIndex; lineNumber < handLines.Length; lineNumber++)
+            {
+                string handLine = handLines[lineNumber];
+
+                try
+                {
+                    bool isFinished = ParseLine(handLine, ref street, handActions, winners);
+
+                    if (isFinished)
+                    {
+                        return lineNumber + 1;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new HandActionException(handLine, "Couldn't parse line '" + handLine + " with ex: " + ex.Message);
+                }
+            }
+            throw new InvalidHandException(string.Join(Environment.NewLine, handActions));
+        }
+
+        public void ParseShowDown(string[] handLines, List<HandAction> handActions, List<WinningsAction> winners, int firstActionIndex, GameType gameType)
+        {
+            for (int i = firstActionIndex; i < handLines.Length; i++)
+            {
+                var line = handLines[i];
+
+                var lastChar = line.Last();
+
+                switch (lastChar)
+                {
+                    // xyz collected $7.50 from pot.
+                    case 't':
+                        if (line.EndsWithFast("pot"))
+                        {
+                            winners.Add(ParseWinnings(line));
+                        }
+                        continue;
+
+                    //*** FLOP *** [6d 7c 6h]
+                    //*** TURN *** [6d 7c 6h] [2s]
+                    //*** RIVER *** [6d 7c 6h 2s] [Qc]
+                    case ']':
+                        continue;
+
+                    //*** SUMMARY ***
+                    //*** SHOWDOWN ***
+                    //*** THIRD RIVER ***
+                    //*** SECOND RIVER ***
+                    //*** THIRD RIVER ***
+                    //*** FIRST SHOWDOWN ***
+                    //*** SECOND SHOWDOWN ***
+                    //*** THIRD SHOWDOWN ***
+                    case '*':
+                        // *** SUMMARY
+                        if (line.StartsWithFast("*** SUM"))
+                        {
+                            return;
+                        }
+                        else if (line.Contains("SHOW"))
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            throw new ArgumentException("Unhandled line: " + line);
+                        }
+                    // 1234abcd: shows[4d 3d] (Pair of Fours)
+                    case ')':
+                        break;
+
+
+                    default:
+                        continue;
+
+                }
+
+                int colonIndex = line.LastIndexOf(':');   // do backwards as players can : in their name
+                var action = ParseMiscShowdownLine(line, colonIndex);
+                handActions.Add(action);
+            }
+        }
+
+        public HandAction ParseMiscShowdownLine(string actionLine, int colonIndex) 
+        { 
+            string playerName = actionLine.Substring(0, colonIndex);
+
+            char actionIdentifier = actionLine[colonIndex + 2];
+
+            switch (actionIdentifier)
+            {
+                case 's': // RECHUK: shows [Ac Qh] (a full house, Aces full of Queens)
+                    return new HandAction(playerName, HandActionType.SHOW, Street.Showdown);
+                default:
+                    throw new HandActionException(actionLine, "ParseMiscShowdownLine: Unrecognized line '" + actionLine + "'");
+            }
+        }
+
+        protected override string ParseHeroName(string[] handlines)
+        {
+            return "Hero";  // In GGPoker hand history, the player's name is always labelled as Hero.
+        }
+
+        protected override long[] ParseHandId(string[] handLines)
+        {
+            // Expect the first line to look like this:
+            // Poker Hand #RC2345481320: Hold'em No Limit  ($0.05/$0.1) - 2018/03/31 14:43:23
+
+            // or
+
+            // Poker Hand #HD138495: Hold'em No Limit  ($0.5/$1) - 2019/10/12 01:43:27
+            string line = handLines[0];
+            string id = line.Split(':')[0].Split(' ')[2].Substring(3);
+            long[] result = new long[1];
+            result[0] = (long)Convert.ToInt64(id);
+            return result;
+        }
+
+        protected override long ParseTournamentId(string[] handLines)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string ParseTableName(string[] handLines)
+        {
+            // Table 'NLHSilver5' 6-max Seat #2 is the button
+            string tableNameWithQuote = handLines[1].Split(' ')[1];
+            return tableNameWithQuote.Substring(1, tableNameWithQuote.Length - 2);
+        }
+
+        protected override PokerFormat ParsePokerFormat(string[] handLines)
+        {
+            // only support cash game for now
+            return PokerFormat.CashGame;
+        }
+
+        protected override SeatType ParseSeatType(string[] handLines)
+        {
+            // Table 'NLHSilver5' 6-max Seat #2 is the button
+            string seatType = handLines[1].Split(" ")[2];
+            if (seatType[0] == '6')
+            {
+                return SeatType.FromMaxPlayers(6);
+            }
+            else if (seatType[0] == '9')
+            {
+                return SeatType.FromMaxPlayers(9);
+            }
+            throw new Exception("Invalid seatType " + handLines[1]);
+        }
+
+        protected override GameType ParseGameType(string[] handLines)
+        {
+            // Only Holdem is supported for now.
+            return GameType.NoLimitHoldem;
+        }
+
+        protected override TableType ParseTableType(string[] handLines)
+        {
+            // Expect the first line to look like this:
+            // Poker Hand #RC2345481320: Hold'em No Limit  ($0.05/$0.1) - 2018/03/31 14:43:23
+
+            // or
+
+            // Poker Hand #HD138495: Hold'em No Limit  ($0.5/$1) - 2019/10/12 01:43:27
+            string type = handLines[0].Substring(12, 2);
+            if (type == "HD")
+            {
+                return TableType.FromTableTypeDescriptions(TableTypeDescription.Regular);
+            }
+            else if (type == "RC")
+            {
+                return TableType.FromTableTypeDescriptions(TableTypeDescription.Zoom);
+            }
+            else
+            {
+                throw new Exception("Unsupported TableType: " + handLines[0]);
+            }
+        }
+
+        protected override Limit ParseLimit(string[] handLines)
+        {
+            // Expect the first line to look like this:
+            // Poker Hand #RC2345481320: Hold'em No Limit  ($0.05/$0.1) - 2018/03/31 14:43:23
+
+            // or
+
+            // Poker Hand #HD138495: Hold'em No Limit  ($0.5/$1) - 2019/10/12 01:43:27
+            string stake = handLines[0].Split(' ')[7];
+            stake = stake.Substring(1, stake.Length - 2);
+            Currency currency = ParseCurrency(handLines[0], stake[0]);
+
+            int slashIndex = stake.IndexOf('/');
+            string smallBlind = stake.Substring(0, slashIndex);
+            string bigBlind = stake.Substring(slashIndex + 1);
+
+            decimal small = smallBlind.ParseAmount();
+            decimal big = bigBlind.ParseAmount();
+
+            return Limit.FromSmallBlindBigBlind(small, big, currency);
+        }
+
+        protected override Buyin ParseBuyin(string[] handLines)
+        {
+            // not support tournament yet
+            throw new NotImplementedException();
+        }
+
+        public override bool IsValidHand(string[] handLines)
+        {
+            // Does not seem to apply to gg.
+            return true;
+        }
+
+        public override bool IsValidOrCancelledHand(string[] handLines, out bool isCancelled)
+        {
+            // Does not seem to apply to gg.
+            isCancelled = false;
+            return true;
+        }
+
+        protected override List<HandAction> ParseHandActions(string[] handLines, GameType gameType, out List<WinningsAction> winners)
+        {
+            int actionIndex = GetFirstActionIndex(handLines);
+
+            List<HandAction> handActions = new List<HandAction>(handLines.Length - actionIndex);
+            winners = new List<WinningsAction>();
+
+            actionIndex = ParseBlindActions(handLines, handActions, actionIndex);
+
+            Street currentStreet;
+            actionIndex = ParseGameActions(handLines, handActions, winners, actionIndex, out currentStreet);
+
+            if (currentStreet == Street.Showdown)
+            {
+                ParseShowDown(handLines, handActions, winners, actionIndex, gameType);
+            }
+
+            return handActions;
+
+        }
+
+        protected override PlayerList ParsePlayers(string[] handLines)
+        {
+            PlayerList playerList = new PlayerList();
+
+            int lineNumber = 2;
+            for (; lineNumber < handLines.Length; lineNumber++)
+            {
+                // Expecting Seat 1: Hero ($124.64 in chips)
+                string line = handLines[lineNumber];
+
+                if (!line.StartsWithFast("Seat "))
+                {
+                    break;
+                }
+
+                const int seatNumberStartIndex = 4;
+                int spaceIndex = line.IndexOf(' ', seatNumberStartIndex);
+                int colonIndex = line.IndexOf(':', spaceIndex + 1);
+                int seatNumber = FastInt.Parse(line, spaceIndex + 1);
+
+                // we need to find the ( before the number. players can have ( in their name so we need to go backwards and skip the last one
+                int openParenIndex = line.LastIndexOf('(');
+                int spaceAfterOpenParen = line.IndexOf(' ', openParenIndex);
+
+                string playerName = line.Substring(colonIndex + 2, (openParenIndex - 1) - (colonIndex + 2));
+
+                string stackString = line.Substring(openParenIndex + 1, spaceAfterOpenParen - (openParenIndex + 1));
+                decimal stack = stackString.ParseAmount();
+
+                playerList.Add(new Player(playerName, stack, seatNumber));
+            }
+
+            for (; lineNumber < handLines.Length; lineNumber++)
+            {
+                string line = handLines[lineNumber];
+
+                // Dealt to Hero [3h 4s]
+                if (line.StartsWithFast("Dealt to") && line.Last() == ']')
+                {
+                    const int nameStartIndex = 9;//"Dealt to ".Length
+                    int cardsStartIndex = line.LastIndexOf('[') + 1;
+                    int nameEndIndex = cardsStartIndex - 2;
+
+                    string name = line.Substring(nameStartIndex, nameEndIndex - nameStartIndex);
+                    string cards = line.Substring(cardsStartIndex, line.Length - cardsStartIndex - 1);
+
+                    playerList[name].HoleCards = HoleCards.FromCards(cards);
+                }
+
+                // 689fsff: shows [4d 3d](Pair of Fours)
+                // Hero: shows [Qs 4s](Pair of Fours)
+                if (line.Contains("shows ["))
+                {
+                    int closeSquareBrackedIndex = line.LastIndexOf(']', line.Length - 1);
+                    int openSquareBracketIndex = line.LastIndexOf('[', closeSquareBrackedIndex);
+                    int colonIndex = line.LastIndexOf(':', openSquareBracketIndex);
+
+                    string playerName = line.Substring(0, colonIndex);
+                    string cards = line.Substring(openSquareBracketIndex + 1, closeSquareBrackedIndex - (openSquareBracketIndex + 1));
+
+                    playerList[playerName].HoleCards = HoleCards.FromCards(cards);
+                }
+            }
+
+            return playerList;
+        }
+
+        public HandAction ParseUncalledBetLine(string actionLine, Street currentStreet)
+        {
+            // Uncalled bet lines look like:
+            // Uncalled bet ($6) returned to woezelenpip
+
+            // position 14 is after the open paren
+            int closeParenIndex = actionLine.IndexOf(')', 14);
+            var amount = actionLine.Substring(14, closeParenIndex - 14);
+
+            int firstLetterOfName = closeParenIndex + 14; // ' returned to ' is length 14
+
+            string playerName = actionLine.Substring(firstLetterOfName, actionLine.Length - firstLetterOfName);
+
+            return new HandAction(playerName, HandActionType.UNCALLED_BET, amount.ParseAmount(), currentStreet);
+        }
+
+        protected override BoardCards ParseCommunityCards(string[] handLines)
+        {
+            for (int i = handLines.Length - 1; i >= 0; i--)
+            {
+                string line = handLines[i];
+                // FIRST Board [3c 9d 3d 8d 7s]
+                // Board [3c 9d 3d 8d 7s]
+                if (line.StartsWithFast("Board") || line.StartsWithFast("FIRST Board"))
+                {
+                    return ParseBoard(line);
+                }
+            }
+            return BoardCards.FromCards(String.Empty);
+        }
+
+        public override RunItTwice[] ParseMultiplerRuns(string[] handLines)
+        {
+            RunItTwice[] multipleRuns = new RunItTwice[3];
+            for (int i = 0; i < 3; i++)
+            {
+                multipleRuns[i] = new RunItTwice();
+            }
+
+            for (int i = 0; i < handLines.Length; i++)
+            {
+                string line = handLines[i];
+                // FIRST Board [3c 9d 3d 8d 7s]
+                // Board [3c 9d 3d 8d 7s]
+                if (line.StartsWithFast("Board") || line.StartsWithFast("FIRST Board"))
+                {
+                    multipleRuns[0].Board = ParseBoard(line);
+                }
+
+                //SECOND Board [8h]
+                if (line.StartsWithFast("SECOND Board"))
+                {
+                    multipleRuns[1].Board = ParseBoard(line, multipleRuns[0].Board);
+                }
+
+                //THIRD Board [8s]
+                //THIRD Board [4c Qc 6c Ac 9c]
+                if (line.StartsWithFast("THIRD Board"))
+                {
+                    multipleRuns[2].Board = ParseBoard(line, multipleRuns[0].Board);
+                }
+
+
+                if (line.StartsWithFast("*** SHOWDOWN") || line.StartsWithFast("*** FIRST SHOWDOWN"))
+                {
+                    i++;
+                    while (i < handLines.Length && !handLines[i].StartsWith("*"))
+                    {
+                        // expect to look like this:
+                        // 125b4606 collected $2.5 from pot
+                        string curLine = handLines[i++];
+                        multipleRuns[0].Winners.Add(ParseWinnings(curLine));
+                    }
+                }
+
+                if (line.StartsWithFast("*** SECOND SHOWDOWN")) 
+                {
+                    i++;
+                    while (i < handLines.Length && !handLines[i].StartsWith("*"))
+                    {
+                        // expect to look like this:
+                        // 125b4606 collected $2.5 from pot
+                        string curLine = handLines[i++];
+                        multipleRuns[1].Winners.Add(ParseWinnings(curLine));
+                    }       
+                }
+
+                if (line.StartsWithFast("*** THIRD SHOWDOWN")) 
+                {
+                    i++;
+                    while (i < handLines.Length && !handLines[i].StartsWith("*"))
+                    {
+                        // expect to look like this:
+                        // 125b4606 collected $2.5 from pot
+                        string curLine = handLines[i++];
+                        multipleRuns[2].Winners.Add(ParseWinnings(curLine));
+                    } 
+                }
+            }
+
+            return multipleRuns;
+        }
+
+        private bool ParseLine(string line, ref Street currentStreet, List<HandAction> handActions, List<WinningsAction> winners)
+        {
+            //We filter out only possible line endings we want
+            char lastChar = line[line.Length - 1];
+
+            // Uncalled bet lines look like:
+            // Uncalled bet ($6) returned to fadfac2sd 
+            if (line.Length > 29 && line[13] == '(')
+            {
+                handActions.Add(ParseUncalledBetLine(line, currentStreet));
+                currentStreet = Street.Showdown;
+                return true;
+            }
+
+            if (line.StartsWithFast("Dealt to"))
+            {
+                return false;
+            }
+
+            switch (lastChar)
+            {
+                //All actions with an amount(BET, CALL, RAISE)
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    break;
+
+                //matze1987: raises $8.94 to $10.94 and is all-in
+                case 'n':
+                    break;
+
+
+                //*** SUMMARY ***
+                //*** SHOW DOWN ***
+                case '*':
+                //*** FLOP *** [Qs Js 3h]
+                //Dealt to PS_Hero [4s 7h]
+                case ']':
+                    char firstChar = line[0];
+
+                    if (firstChar == '*')
+                    {
+                        return ParseCurrentStreet(line, ref currentStreet);
+                    }
+                    return false;
+
+                // xyz: folds
+                // xyz: checks
+                case 's':
+                    if (line.EndsWithFast(" folds") || line.EndsWithFast(" checks")) { break; }
+                    goto default;
+                    
+                default:
+                    return false;
+            }
+
+            int colonIndex = line.LastIndexOf(':'); // do backwards as players can have : in their name
+
+            switch (currentStreet)
+            {
+                case Street.Showdown:
+                case Street.Null:
+                    throw new HandActionException("", "Invalid State: Street");
+
+                default:
+                    if (colonIndex > -1 && line[line.Length - 1] != 't')
+                    {
+                        handActions.Add(ParseRegularActionLine(line, colonIndex, currentStreet));
+                    }
+                    else
+                    {
+                        winners.Add(ParseWinnings(line));
+                    }
+                    break;
+            }
+
+            return false;
+        }
+
+        public HandAction ParseRegularActionLine(string actionLine, int colonIndex, Street currentStreet)
+        {
+
+            string playerName = actionLine.Substring(0, colonIndex);
+
+            // all-in likes look like: 'Piotr280688: raises $8.32 to $12.88 and is all-in'
+            bool isAllIn = actionLine[actionLine.Length - 1] == 'n';
+            if (isAllIn)// Remove the  ' and is all in' and just proceed like normal
+            {
+                actionLine = actionLine.Remove(actionLine.Length - 14);
+            }
+
+            // lines that reach the cap look like tzuiop23: calls $62 and has reached the $80 cap
+            bool hasReachedCap = actionLine[actionLine.Length - 1] == 'p';
+            if (hasReachedCap)// Remove the  ' and has reached the $80 cap' and just proceed like normal
+            {
+                int lastNonCapCharacter = actionLine.LastIndexOf('n') - 2;  // find the n in the and
+                actionLine = actionLine.Remove(lastNonCapCharacter);
+            }
+
+            char actionIdentifier = actionLine[colonIndex + 2];
+
+            HandActionType actionType;
+            decimal amount;
+            int firstDigitIndex;
+
+            switch (actionIdentifier)
+            {
+                //gaydaddy: folds
+                case 'f':
+                    return new HandAction(playerName, HandActionType.FOLD, currentStreet);
+
+                case 'c':
+                    //Piotr280688: checks
+                    if (actionLine[colonIndex + 3] == 'h')
+                    {
+                        return new HandAction(playerName, HandActionType.CHECK, currentStreet);
+                    }
+                    //MECO-LEO: calls $1.23
+                    firstDigitIndex = actionLine.LastIndexOf(' ') + 1;
+                    amount = actionLine.Substring(firstDigitIndex, actionLine.Length - firstDigitIndex).ParseAmount();
+                    actionType = HandActionType.CALL;
+                    break;
+
+                //MS13ZEN: bets $1.76
+                case 'b':
+                    firstDigitIndex = actionLine.LastIndexOf(' ') + 1;
+                    amount = actionLine.Substring(firstDigitIndex, actionLine.Length - firstDigitIndex).ParseAmount();
+                    actionType = HandActionType.BET;
+                    break;
+
+                //Zypherin: raises $6400 to $8300              
+                case 'r':
+                    firstDigitIndex = actionLine.LastIndexOf(' ') + 1;
+                    amount = actionLine.Substring(firstDigitIndex, actionLine.Length - firstDigitIndex).ParseAmount();
+                    actionType = HandActionType.RAISE;
+                    break;
+                default:
+                    throw new HandActionException(actionLine, "ParseRegularActionLine: Unrecognized line:" + actionLine);
+            }
+
+            return new HandAction(playerName, actionType, amount, currentStreet, isAllIn);
+        }
+
+
+        private int GetFirstActionIndex(string[] handLines)
+        {
+            for (int lineNumber = 2; lineNumber < handLines.Length; lineNumber++)
+            {
+                // Seat 8: 4fgjkscjfds ($100.51 in chips)
+                // fasjeif21: posts small blind $5
+                string line = handLines[lineNumber];
+                if (line[0] != 'S' || line[line.Length - 1] != ')')
+                {
+                    return lineNumber;
+                }
+            }
+
+            throw new HandActionException(string.Empty, "GetFirstActionIndex: Couldn't find it.");
+        }
+
+        private static bool ParseCurrentStreet(string line, ref Street currentStreet)
+        {
+            char typeOfEventChar = line[7];
+
+            // this way we implement the collected lines in the regular showdown for the hand
+            // both showdowns will be included in the regular hand actions, so the regular hand actions can be used for betting/pot/rake verification
+            // might be readjusted so that only the first one is the regular handactions, and the second one goes to runittwice
+
+            // *** FIRST FLOP
+            // *** FIRST TURN
+            if (typeOfEventChar == 'S')
+                typeOfEventChar = line[13];
+
+            // *** SECOND FLOP
+            // *** SECOND TURN
+            if (typeOfEventChar == 'O')
+                typeOfEventChar = line[14];
+
+
+            // *** THIRD FLOP
+            // *** THIRD TURN
+            if (typeOfEventChar == 'R')
+                typeOfEventChar = line[13];
+
+            switch (typeOfEventChar)
+            {
+                case 'P':
+                    currentStreet = Street.Flop;
+                    return false;
+                case 'N':
+                    currentStreet = Street.Turn;
+                    return false;
+                case 'E':
+                    currentStreet = Street.River;
+                    return false;
+                case 'W':
+                    currentStreet = Street.Showdown;
+                    return true;
+                case 'M':
+                    return true;
+                default:
+                    throw new HandActionException(line, "Unrecognized line w/ a *:" + line);
+            }
+        }
+
+        private BoardCards ParseBoard(string line)
+        {
+            int openBracketIndex = line.IndexOf('[');
+            int closeBracketIndex = line.IndexOf(']', openBracketIndex);
+
+            return BoardCards.FromCards(line.Substring(openBracketIndex + 1, closeBracketIndex - openBracketIndex - 1));
+        }
+
+        private BoardCards ParseBoard(string line, BoardCards baseBoard)
+        {
+            BoardCards newRunBoard = ParseBoard(line);
+            switch (newRunBoard.Count)
+            {
+                case 1:
+                    return BoardCards.FromCards(baseBoard.GetCards().GetRange(0, 4).Concat(newRunBoard.GetCards()).ToArray());
+
+                case 2:
+                    return BoardCards.FromCards(baseBoard.GetCards().GetRange(0, 3).Concat(newRunBoard.GetCards()).ToArray());
+
+                case 5:
+                    return newRunBoard;
+
+                default:
+                    throw new Exception("Parse board failed: " + line);
+            }
+        }
+
+        public WinningsAction ParseWinnings(string line)
+        {
+            // 12b64606 collected $2.5 from pot
+            int firstSpaceIndex = line.IndexOf(" collected");
+            int dollarSignIndex = line.LastIndexOf('$');
+            int amountEndingIndex = line.Length - 8;
+
+            string playerName = line.Substring(0, firstSpaceIndex);
+            string amount = line.Substring(dollarSignIndex, amountEndingIndex - dollarSignIndex - 1);
+
+            // 0 for main pot. In gg hand history, it does not show side pot information.
+            return new WinningsAction(playerName, WinningsActionType.WINS, amount.ParseAmount(), 0);
+        }
+
+        private Currency ParseCurrency(string handLine, char currencySymbol)
+        {
+            switch (currencySymbol)
+            {
+                case '$':
+                    _numberFormatInfo.CurrencySymbol = "$";
+                    return Currency.USD;
+                case '€':
+                    _numberFormatInfo.CurrencySymbol = "€";
+                    return Currency.EURO;
+                case '£':
+                    _numberFormatInfo.CurrencySymbol = "£";
+                    return Currency.GBP;
+                case '¥':
+                    _numberFormatInfo.CurrencySymbol = "¥";
+                    return Currency.CNY;
+
+                default:
+                    throw new CurrencyException(handLine, "Unrecognized currency symbol " + currencySymbol);
+            }
+        }
+
+    }
+}

--- a/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
@@ -539,7 +539,7 @@ namespace HandHistories.Parser.Parsers.FastParser.GGPoker
                     return ParseBoard(line);
                 }
             }
-            return null;
+            return BoardCards.ForPreflop();
         }
 
         public override RunItTwice[] ParseMultiplerRuns(string[] handLines)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The poker hand-history parser currently supports the following sites:
  * Winning Poker
  * Boss Media
  * Entraction (deprecated)
+ * GGPoker (NLH Cash Game Only)
 
 Format Support
 --------------


### PR DESCRIPTION
*  GGPoker NLH cash game parser + Unit tests
*  4 Sample hand history files
*  Add equality comparator for HoleCards + Unit Tests
*  Add equality comparator for PlayerList + Unit Tests
*  Add equality comparator for RunItTwice + Unit Tests.
*  Added new Post Type (Straddle)
*  Added RunMultipleTimes (GG support run it 3 times)