### PR TITLE
Add equality comparator for BoardCards + Unit tests

### DIFF
--- a/HandHistories.Objects.UnitTests/Cards/BoardCardsTests.cs
+++ b/HandHistories.Objects.UnitTests/Cards/BoardCardsTests.cs
@@ -1,0 +1,145 @@
+﻿using HandHistories.Objects.Cards;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Runtime.ConstrainedExecution;
+using System.Text;
+
+namespace HandHistories.Objects.UnitTests.Cards
+{
+    [TestFixture]
+    public class BoardCardsTests
+    {
+        private static Card C1 = new Card("A", "c");
+        private static Card C2 = new Card("K", "d");
+        private static Card C3 = new Card("2", "h");
+        private static Card C4 = new Card("2", "d");
+        private static Card C5 = new Card("9", "s");
+        private static Card C6 = new Card("7", "s");
+
+        [Test]
+        public void BoardCardsTest_EqualityTest_CompareWithSelf_ReturnTrue()
+        {
+            BoardCards emptyBoard = BoardCards.FromCards(String.Empty);
+            BoardCards boardWithFlop = BoardCards.FromCards("AcQsTh");
+            BoardCards boardWithTurn = BoardCards.FromCards("AcQsTh2h");
+            BoardCards boardWithRiver = BoardCards.FromCards("AcQsTh2h3d");
+            
+            Assert.IsTrue(emptyBoard.Equals(emptyBoard));
+            Assert.IsTrue(boardWithFlop.Equals(boardWithFlop));
+            Assert.IsTrue(boardWithTurn.Equals(boardWithTurn));
+            Assert.IsTrue(boardWithRiver.Equals(boardWithRiver));
+        }
+
+        [Test]
+        public void BoardCardsTest_FlopEqualityTest_DifferentOrder_ReturnsTrue()
+        {
+
+            BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
+            BoardCards b2 = BoardCards.ForFlop(C1, C3, C2);
+            BoardCards b3 = BoardCards.ForFlop(C2, C1, C3);
+            BoardCards b4 = BoardCards.ForFlop(C2, C3, C1);
+            BoardCards b5 = BoardCards.ForFlop(C3, C1, C2);
+            BoardCards b6 = BoardCards.ForFlop(C3, C2, C1);
+
+            Assert.IsTrue(b1.Equals(b2));
+            Assert.IsTrue(b1.Equals(b3));
+            Assert.IsTrue(b1.Equals(b4));
+            Assert.IsTrue(b1.Equals(b5));
+            Assert.IsTrue(b1.Equals(b6));
+            
+            Assert.IsTrue(b2.Equals(b3));
+            Assert.IsTrue(b2.Equals(b4));
+            Assert.IsTrue(b2.Equals(b5));
+            Assert.IsTrue(b2.Equals(b6));
+
+            Assert.IsTrue(b3.Equals(b4));
+            Assert.IsTrue(b3.Equals(b5));
+            Assert.IsTrue(b3.Equals(b6));
+
+            Assert.IsTrue(b4.Equals(b5));
+            Assert.IsTrue(b4.Equals(b6));
+
+            Assert.IsTrue(b5.Equals(b6));
+        }
+
+        [Test]
+        public void BoardCardsTest_FlopEqualityTest_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
+            BoardCards b2 = BoardCards.ForFlop(C1, C2, C4);
+            BoardCards b3 = BoardCards.ForFlop(C1, C3, C4);
+            BoardCards b4 = BoardCards.ForFlop(C2, C3, C4);
+
+            Assert.IsFalse(b1.Equals(b2));
+            Assert.IsFalse(b1.Equals(b3));
+            Assert.IsFalse(b1.Equals(b4));
+            Assert.IsFalse(b2.Equals(b3));
+            Assert.IsFalse(b2.Equals(b4));
+            Assert.IsFalse(b3.Equals(b4));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTest_ReturnsTrue()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C1, C3, C2, C4);
+            BoardCards b3 = BoardCards.ForTurn(C3, C2, C1, C4);
+
+            Assert.IsTrue(b1.Equals(b2)); 
+            Assert.IsTrue(b2.Equals(b3)); 
+            Assert.IsTrue(b1.Equals(b3));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTest_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C1, C2, C3, C5);
+            BoardCards b3 = BoardCards.ForTurn(C1, C2, C5, C4);
+
+            Assert.IsFalse(b1.Equals(b2));
+            Assert.IsFalse(b1.Equals(b3));
+            Assert.IsFalse(b2.Equals(b3));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTest_SameCardsWithDifferentOrder_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C4, C2, C3, C1);
+
+            Assert.IsFalse(b1.Equals(b2));
+        }
+
+
+        [Test]
+        public void BoardCardsTest_RiverEqualityTest_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
+            BoardCards b2 = BoardCards.ForRiver(C1, C2, C3, C4, C6);
+            BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C6, C5);
+
+            Assert.IsFalse(b1.Equals(b2));
+            Assert.IsFalse(b1.Equals(b3));
+            Assert.IsFalse(b2.Equals(b3));
+        }
+
+        [Test]
+        public void BoardCardsTest_RiverEqualityTest_SameCardsWithDifferentOrder_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
+            BoardCards b2 = BoardCards.ForRiver(C4, C2, C3, C1, C5);
+            BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C5, C4);
+            BoardCards b4 = BoardCards.ForRiver(C1, C2, C5, C3, C4);
+
+            Assert.IsFalse(b1.Equals(b2));
+            Assert.IsFalse(b1.Equals(b3));
+            Assert.IsFalse(b1.Equals(b4));
+            Assert.IsFalse(b2.Equals(b3));
+            Assert.IsFalse(b2.Equals(b4));
+            Assert.IsFalse(b3.Equals(b4));
+        }
+
+    }
+}

--- a/HandHistories.Objects.UnitTests/Cards/BoardCardsTests.cs
+++ b/HandHistories.Objects.UnitTests/Cards/BoardCardsTests.cs
@@ -18,21 +18,21 @@ namespace HandHistories.Objects.UnitTests.Cards
         private static Card C6 = new Card("7", "s");
 
         [Test]
-        public void BoardCardsTest_EqualityTest_CompareWithSelf_ReturnTrue()
+        public void BoardCardsTest_EqualityTestWithHoldemOmahaRule_CompareWithSelf_ReturnTrue()
         {
             BoardCards emptyBoard = BoardCards.FromCards(String.Empty);
             BoardCards boardWithFlop = BoardCards.FromCards("AcQsTh");
             BoardCards boardWithTurn = BoardCards.FromCards("AcQsTh2h");
             BoardCards boardWithRiver = BoardCards.FromCards("AcQsTh2h3d");
-            
-            Assert.IsTrue(emptyBoard.Equals(emptyBoard));
-            Assert.IsTrue(boardWithFlop.Equals(boardWithFlop));
-            Assert.IsTrue(boardWithTurn.Equals(boardWithTurn));
-            Assert.IsTrue(boardWithRiver.Equals(boardWithRiver));
+
+            Assert.IsTrue(emptyBoard.EqualsViaHoldemOmahaRule(emptyBoard));
+            Assert.IsTrue(boardWithFlop.EqualsViaHoldemOmahaRule(boardWithFlop));
+            Assert.IsTrue(boardWithTurn.EqualsViaHoldemOmahaRule(boardWithTurn));
+            Assert.IsTrue(boardWithRiver.EqualsViaHoldemOmahaRule(boardWithRiver));
         }
 
         [Test]
-        public void BoardCardsTest_FlopEqualityTest_DifferentOrder_ReturnsTrue()
+        public void BoardCardsTest_FlopEqualityTestWithHoldemOmahaRule_DifferentOrder_ReturnsTrue()
         {
 
             BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
@@ -42,104 +42,235 @@ namespace HandHistories.Objects.UnitTests.Cards
             BoardCards b5 = BoardCards.ForFlop(C3, C1, C2);
             BoardCards b6 = BoardCards.ForFlop(C3, C2, C1);
 
-            Assert.IsTrue(b1.Equals(b2));
-            Assert.IsTrue(b1.Equals(b3));
-            Assert.IsTrue(b1.Equals(b4));
-            Assert.IsTrue(b1.Equals(b5));
-            Assert.IsTrue(b1.Equals(b6));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b2));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b5));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b6));
             
-            Assert.IsTrue(b2.Equals(b3));
-            Assert.IsTrue(b2.Equals(b4));
-            Assert.IsTrue(b2.Equals(b5));
-            Assert.IsTrue(b2.Equals(b6));
+            Assert.IsTrue(b2.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsTrue(b2.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsTrue(b2.EqualsViaHoldemOmahaRule(b5));
+            Assert.IsTrue(b2.EqualsViaHoldemOmahaRule(b6));
 
-            Assert.IsTrue(b3.Equals(b4));
-            Assert.IsTrue(b3.Equals(b5));
-            Assert.IsTrue(b3.Equals(b6));
+            Assert.IsTrue(b3.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsTrue(b3.EqualsViaHoldemOmahaRule(b5));
+            Assert.IsTrue(b3.EqualsViaHoldemOmahaRule(b6));
 
-            Assert.IsTrue(b4.Equals(b5));
-            Assert.IsTrue(b4.Equals(b6));
+            Assert.IsTrue(b4.EqualsViaHoldemOmahaRule(b5));
+            Assert.IsTrue(b4.EqualsViaHoldemOmahaRule(b6));
 
-            Assert.IsTrue(b5.Equals(b6));
+            Assert.IsTrue(b5.EqualsViaHoldemOmahaRule(b6));
         }
 
         [Test]
-        public void BoardCardsTest_FlopEqualityTest_DifferentCards_ReturnsFalse()
+        public void BoardCardsTest_FlopEqualityTestWithHoldemOmahaRule_DifferentCards_ReturnsFalse()
         {
             BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
             BoardCards b2 = BoardCards.ForFlop(C1, C2, C4);
             BoardCards b3 = BoardCards.ForFlop(C1, C3, C4);
             BoardCards b4 = BoardCards.ForFlop(C2, C3, C4);
 
-            Assert.IsFalse(b1.Equals(b2));
-            Assert.IsFalse(b1.Equals(b3));
-            Assert.IsFalse(b1.Equals(b4));
-            Assert.IsFalse(b2.Equals(b3));
-            Assert.IsFalse(b2.Equals(b4));
-            Assert.IsFalse(b3.Equals(b4));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b2));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsFalse(b3.EqualsViaHoldemOmahaRule(b4));
         }
 
         [Test]
-        public void BoardCardsTest_TurnEqualityTest_ReturnsTrue()
+        public void BoardCardsTest_TurnEqualityTestWithHoldemOmahaRule_ReturnsTrue()
         {
             BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
             BoardCards b2 = BoardCards.ForTurn(C1, C3, C2, C4);
             BoardCards b3 = BoardCards.ForTurn(C3, C2, C1, C4);
 
-            Assert.IsTrue(b1.Equals(b2)); 
-            Assert.IsTrue(b2.Equals(b3)); 
-            Assert.IsTrue(b1.Equals(b3));
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b2)); 
+            Assert.IsTrue(b2.EqualsViaHoldemOmahaRule(b3)); 
+            Assert.IsTrue(b1.EqualsViaHoldemOmahaRule(b3));
         }
 
         [Test]
-        public void BoardCardsTest_TurnEqualityTest_DifferentCards_ReturnsFalse()
+        public void BoardCardsTest_TurnEqualityTestWithHoldemOmahaRule_DifferentCards_ReturnsFalse()
         {
             BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
             BoardCards b2 = BoardCards.ForTurn(C1, C2, C3, C5);
             BoardCards b3 = BoardCards.ForTurn(C1, C2, C5, C4);
 
-            Assert.IsFalse(b1.Equals(b2));
-            Assert.IsFalse(b1.Equals(b3));
-            Assert.IsFalse(b2.Equals(b3));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b2));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b3));
         }
 
         [Test]
-        public void BoardCardsTest_TurnEqualityTest_SameCardsWithDifferentOrder_ReturnsFalse()
+        public void BoardCardsTest_TurnEqualityTestWithHoldemOmahaRule_SameCardsWithDifferentOrder_ReturnsFalse()
         {
             BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
             BoardCards b2 = BoardCards.ForTurn(C4, C2, C3, C1);
 
-            Assert.IsFalse(b1.Equals(b2));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b2));
         }
 
 
         [Test]
-        public void BoardCardsTest_RiverEqualityTest_DifferentCards_ReturnsFalse()
+        public void BoardCardsTest_RiverEqualityTestWithHoldemOmahaRule_DifferentCards_ReturnsFalse()
         {
             BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
             BoardCards b2 = BoardCards.ForRiver(C1, C2, C3, C4, C6);
             BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C6, C5);
 
-            Assert.IsFalse(b1.Equals(b2));
-            Assert.IsFalse(b1.Equals(b3));
-            Assert.IsFalse(b2.Equals(b3));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b2));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b3));
         }
 
         [Test]
-        public void BoardCardsTest_RiverEqualityTest_SameCardsWithDifferentOrder_ReturnsFalse()
+        public void BoardCardsTest_RiverEqualityTestWithHoldemOmahaRule_SameCardsWithDifferentOrder_ReturnsFalse()
         {
             BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
             BoardCards b2 = BoardCards.ForRiver(C4, C2, C3, C1, C5);
             BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C5, C4);
             BoardCards b4 = BoardCards.ForRiver(C1, C2, C5, C3, C4);
 
-            Assert.IsFalse(b1.Equals(b2));
-            Assert.IsFalse(b1.Equals(b3));
-            Assert.IsFalse(b1.Equals(b4));
-            Assert.IsFalse(b2.Equals(b3));
-            Assert.IsFalse(b2.Equals(b4));
-            Assert.IsFalse(b3.Equals(b4));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b2));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b1.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b3));
+            Assert.IsFalse(b2.EqualsViaHoldemOmahaRule(b4));
+            Assert.IsFalse(b3.EqualsViaHoldemOmahaRule(b4));
+        }
+
+        [Test]
+        public void BoardCardsTest_EqualityTestWithCourchecvelRule_CompareWithSelf_ReturnTrue()
+        {
+            BoardCards emptyBoard = BoardCards.FromCards(String.Empty);
+            BoardCards boardWithFlop = BoardCards.FromCards("AcQsTh");
+            BoardCards boardWithTurn = BoardCards.FromCards("AcQsTh2h");
+            BoardCards boardWithRiver = BoardCards.FromCards("AcQsTh2h3d");
+
+            Assert.IsTrue(emptyBoard.EqualsViaCourchevelRule(emptyBoard));
+            Assert.IsTrue(boardWithFlop.EqualsViaCourchevelRule(boardWithFlop));
+            Assert.IsTrue(boardWithTurn.EqualsViaCourchevelRule(boardWithTurn));
+            Assert.IsTrue(boardWithRiver.EqualsViaCourchevelRule(boardWithRiver));
+        }
+
+        [Test]
+        public void BoardCardsTest_FlopEqualityTestWithCourchecvelRule_DifferentOrder_ReturnsTrue()
+        {
+
+            BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
+            BoardCards b2 = BoardCards.ForFlop(C1, C3, C2);
+            BoardCards b3 = BoardCards.ForFlop(C2, C1, C3);
+            BoardCards b4 = BoardCards.ForFlop(C2, C3, C1);
+            BoardCards b5 = BoardCards.ForFlop(C3, C1, C2);
+            BoardCards b6 = BoardCards.ForFlop(C3, C2, C1);
+
+            Assert.IsTrue(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsTrue(b3.EqualsViaCourchevelRule(b4));
+            Assert.IsTrue(b5.EqualsViaCourchevelRule(b6));
+        }
+
+        [Test]
+        public void BoardCardsTest_FlopEqualityTestWithCourchecvelRule_DifferentOrder_ReturnsFalse()
+        {
+
+            BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
+            BoardCards b2 = BoardCards.ForFlop(C1, C3, C2);
+            BoardCards b3 = BoardCards.ForFlop(C2, C1, C3);
+            BoardCards b4 = BoardCards.ForFlop(C2, C3, C1);
+            BoardCards b5 = BoardCards.ForFlop(C3, C1, C2);
+            BoardCards b6 = BoardCards.ForFlop(C3, C2, C1);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b5));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b6));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b5));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b6));
+            Assert.IsFalse(b3.EqualsViaCourchevelRule(b5));
+            Assert.IsFalse(b3.EqualsViaCourchevelRule(b6));
+        }
+
+        [Test]
+        public void BoardCardsTest_FlopEqualityTestWithCourchecvelRule_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForFlop(C1, C2, C3);
+            BoardCards b2 = BoardCards.ForFlop(C1, C2, C4);
+            BoardCards b3 = BoardCards.ForFlop(C1, C3, C4);
+            BoardCards b4 = BoardCards.ForFlop(C2, C3, C4);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b3.EqualsViaCourchevelRule(b4));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTestWithCourchecvelRule_ReturnsTrue()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C1, C3, C2, C4);
+
+            Assert.IsTrue(b1.EqualsViaCourchevelRule(b2));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTestWithCourchecvelRule_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C1, C2, C3, C5);
+            BoardCards b3 = BoardCards.ForTurn(C1, C2, C5, C4);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b3));
+        }
+
+        [Test]
+        public void BoardCardsTest_TurnEqualityTestWithCourchecvelRule_SameCardsWithDifferentOrder_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForTurn(C1, C2, C3, C4);
+            BoardCards b2 = BoardCards.ForTurn(C4, C2, C3, C1);
+            BoardCards b3 = BoardCards.ForTurn(C1, C4, C3, C2);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b3));
+        }
+
+
+        [Test]
+        public void BoardCardsTest_RiverEqualityTestWithCourchecvelRule_DifferentCards_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
+            BoardCards b2 = BoardCards.ForRiver(C1, C2, C3, C4, C6);
+            BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C6, C5);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b3));
+        }
+
+        [Test]
+        public void BoardCardsTest_RiverEqualityTestWithCourchecvelRule_SameCardsWithDifferentOrder_ReturnsFalse()
+        {
+            BoardCards b1 = BoardCards.ForRiver(C1, C2, C3, C4, C5);
+            BoardCards b2 = BoardCards.ForRiver(C4, C2, C3, C1, C5);
+            BoardCards b3 = BoardCards.ForRiver(C1, C2, C3, C5, C4);
+            BoardCards b4 = BoardCards.ForRiver(C1, C2, C5, C3, C4);
+
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b2));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b1.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b3));
+            Assert.IsFalse(b2.EqualsViaCourchevelRule(b4));
+            Assert.IsFalse(b3.EqualsViaCourchevelRule(b4));
         }
 
     }
+
 }

--- a/HandHistories.Objects/Cards/BoardCards.cs
+++ b/HandHistories.Objects/Cards/BoardCards.cs
@@ -8,28 +8,28 @@ namespace HandHistories.Objects.Cards
     {
         public Street Street
         {
-           get
-           {
-               switch (Cards.Count)
-               {
-                   case 0:
-                       return Street.Preflop;
-                   case 3:
-                       return Street.Flop;
-                   case 4:
-                       return Street.Turn;
-                   case 5:
-                       return Street.River;
-                   default:
-                       throw new ArgumentException("Unknown number of board cards " + Cards.Count);
-               }
-           }
+            get
+            {
+                switch (Cards.Count)
+                {
+                    case 0:
+                        return Street.Preflop;
+                    case 3:
+                        return Street.Flop;
+                    case 4:
+                        return Street.Turn;
+                    case 5:
+                        return Street.River;
+                    default:
+                        throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+                }
+            }
         }
 
         private BoardCards(params Card[] cards)
             : base(cards)
         {
-            
+
         }
 
         public static BoardCards ForPreflop()
@@ -58,7 +58,7 @@ namespace HandHistories.Objects.Cards
         }
 
         public static BoardCards FromCards(Card[] cards)
-        {            
+        {
             return new BoardCards(cards);
         }
 
@@ -79,5 +79,94 @@ namespace HandHistories.Objects.Cards
                     throw new ArgumentException("Can't get board in for null street");
             }
         }
+
+        public Card GetTurnCard()
+        {
+            switch (this.Count)
+            {
+                case 0:
+                case 3:
+                    throw new Exception("Turn card does not exist on this board!");
+                case 4:
+                case 5:
+                    return this[3];
+                default:
+                    throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+
+            }
+        }
+
+        public Card GetRiverCard()
+        {
+            switch (this.Count)
+            {
+                case 0:
+                case 3:
+                case 4:
+                    throw new Exception("River card does not exist on this board!");
+                case 5:
+                    return this[4];
+                default:
+                    throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+            }
+        }
+
+        /**
+         * When comparing two boards, order matters. The same 5 cards, if come to the board with different order, should be considerred as different
+         * boards. Therefore, when comparing two boards, we should firstly compare Flop as a group, and then compare Turn and River respecticely.
+         */
+        public override bool Equals(object obj)
+        {
+            bool stringEquality = obj.ToString().Equals(ToString());
+            if (stringEquality) return true;
+
+            BoardCards boardGroup = obj as BoardCards;
+
+            if (boardGroup == null) return false;
+
+            if (this.Count != boardGroup.Count) return false;
+            if (this.Count == 0) return true;
+
+            // if this is just comparing flops, we can use the base compartor.
+            if (this.Count == 3)
+            {
+                return base.Equals(boardGroup);
+            }
+
+            // because the order matters, we need to compare flop first, and then compare turn and river.
+            if (this.Count == 4)
+            {
+                return this.GetBoardOnStreet(Street.Flop).Equals(boardGroup.GetBoardOnStreet(Street.Flop)) && this.GetTurnCard().Equals(boardGroup.GetTurnCard());
+            }
+
+            if (this.Count == 5)
+            {
+                return this.GetBoardOnStreet(Street.Turn).Equals(boardGroup.GetBoardOnStreet(Street.Turn)) && this.GetRiverCard().Equals(boardGroup.GetRiverCard());
+            }
+
+            throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+        }
+
+        public static bool operator ==(BoardCards b1, BoardCards b2)
+        {
+            if (ReferenceEquals(b1, b2))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(b1, null) || ReferenceEquals(b2, null))
+            {
+                return false;
+            }
+
+            return b1.Equals(b2);
+        }
+
+        public static bool operator !=(BoardCards b1, BoardCards b2) { return !(b1 == b2); }
+
+        public override int GetHashCode()
+        {
+            return (Cards != null ? Cards.GetHashCode() : 0);
+        }
     }
 }
+

--- a/HandHistories.Objects/Cards/BoardCards.cs
+++ b/HandHistories.Objects/Cards/BoardCards.cs
@@ -80,92 +80,77 @@ namespace HandHistories.Objects.Cards
             }
         }
 
-        public Card GetTurnCard()
+        public bool EqualsViaHoldemOmahaRule(BoardCards other)
         {
-            switch (this.Count)
+            if (other == null) return false;
+            if (other.Cards.Count != this.Cards.Count) return false;
+
+            switch (Cards.Count)
             {
+                case 5: // River
+                    if (Cards[4] != other.Cards[4])
+                    {
+                        return false;
+                    }
+                    goto case 4;
+                case 4: // Turn
+                    if (Cards[3] != other.Cards[3])
+                    {
+                        return false;
+                    }
+                    goto case 3;
+                case 3: // Flop
+                    ulong thismask = 1ul << this.Cards[0].CardIntValue
+                                   | 1ul << this.Cards[1].CardIntValue
+                                   | 1ul << this.Cards[2].CardIntValue;
+
+                    ulong othermask = 1ul << other.Cards[0].CardIntValue
+                                    | 1ul << other.Cards[1].CardIntValue
+                                    | 1ul << other.Cards[2].CardIntValue;
+
+                    return thismask == othermask;
+                case 0: // Preflop
+                    return true;
+
+                default: throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+            }
+        }
+
+        public bool EqualsViaCourchevelRule(BoardCards other)
+        {
+            if (other == null) return false;
+            if (other.Cards.Count != this.Cards.Count) return false;
+
+            switch (Cards.Count)
+            {
+                case 5: // River
+                    if (Cards[4] != other.Cards[4])
+                    {
+                        return false;
+                    }
+                    goto case 4;
+                case 4: // Turn
+                    if (Cards[3] != other.Cards[3])
+                    {
+                        return false;
+                    }
+                    goto case 3;
+                case 3: // Flop
+                    ulong thismask = 1ul << this.Cards[1].CardIntValue
+                                   | 1ul << this.Cards[2].CardIntValue;
+
+                    ulong othermask = 1ul << other.Cards[1].CardIntValue
+                                    | 1ul << other.Cards[2].CardIntValue;
+
+                    if (thismask != othermask) return false;
+                    goto case 1;
+                case 1: // Preflop
+                    return Cards[0] == other.Cards[0];
                 case 0:
-                case 3:
-                    throw new Exception("Turn card does not exist on this board!");
-                case 4:
-                case 5:
-                    return this[3];
-                default:
-                    throw new ArgumentException("Unknown number of board cards " + Cards.Count);
+                    return true;
 
+                default: throw new ArgumentException("Unknown number of board cards " + Cards.Count);
             }
-        }
-
-        public Card GetRiverCard()
-        {
-            switch (this.Count)
-            {
-                case 0:
-                case 3:
-                case 4:
-                    throw new Exception("River card does not exist on this board!");
-                case 5:
-                    return this[4];
-                default:
-                    throw new ArgumentException("Unknown number of board cards " + Cards.Count);
-            }
-        }
-
-        /**
-         * When comparing two boards, order matters. The same 5 cards, if come to the board with different order, should be considerred as different
-         * boards. Therefore, when comparing two boards, we should firstly compare Flop as a group, and then compare Turn and River respecticely.
-         */
-        public override bool Equals(object obj)
-        {
-            bool stringEquality = obj.ToString().Equals(ToString());
-            if (stringEquality) return true;
-
-            BoardCards boardGroup = obj as BoardCards;
-
-            if (boardGroup == null) return false;
-
-            if (this.Count != boardGroup.Count) return false;
-            if (this.Count == 0) return true;
-
-            // if this is just comparing flops, we can use the base compartor.
-            if (this.Count == 3)
-            {
-                return base.Equals(boardGroup);
-            }
-
-            // because the order matters, we need to compare flop first, and then compare turn and river.
-            if (this.Count == 4)
-            {
-                return this.GetBoardOnStreet(Street.Flop).Equals(boardGroup.GetBoardOnStreet(Street.Flop)) && this.GetTurnCard().Equals(boardGroup.GetTurnCard());
-            }
-
-            if (this.Count == 5)
-            {
-                return this.GetBoardOnStreet(Street.Turn).Equals(boardGroup.GetBoardOnStreet(Street.Turn)) && this.GetRiverCard().Equals(boardGroup.GetRiverCard());
-            }
-
-            throw new ArgumentException("Unknown number of board cards " + Cards.Count);
-        }
-
-        public static bool operator ==(BoardCards b1, BoardCards b2)
-        {
-            if (ReferenceEquals(b1, b2))
-            {
-                return true;
-            }
-            else if (ReferenceEquals(b1, null) || ReferenceEquals(b2, null))
-            {
-                return false;
-            }
-
-            return b1.Equals(b2);
-        }
-
-        public static bool operator !=(BoardCards b1, BoardCards b2) { return !(b1 == b2); }
-
-        public override int GetHashCode()
-        {
-            return (Cards != null ? Cards.GetHashCode() : 0);
         }
     }
 }


### PR DESCRIPTION
For Boards, we need a different comparison logic than the base class CardGroup. The reason is the order matters for most poker games with community cards.

The correct comparison logic is to compare the Flop as a group where the order does not matter within the Flop, and then compare Turn and River respectively where the order matters.

Example:

AsKsTh 2h 3h == ThKsAs 2h 3h  (Order does not matter within Flop)
AsKsTh 2h 3h !=  AsKsTh 3h 2h  (Order matters when 2h shows in Turn or River)
AsKsTh 2h 3h !=  AsKs2h Th 3h  (Order matters when 2h shows up in Flop other than Turn)
