### PR TITLE
Parsing limit space fix

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -387,6 +387,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\MultiplePosts.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\NewLimitFormat.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="SampleHandHistories\GGPoker\CashGame\GeneralHands\PaysCashoutFee.txt">

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/GGPoker/GGPokerHandSummaryParserExtraTests.cs
@@ -785,5 +785,78 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.GGPoker
             TestFullHandHistorySummary(expectedSummary, "PaysCashoutFee");
             TestHandHistory(expectedHandHistory, "PaysCashoutFee");
         }
+
+        [Test]
+        public void NewLimitFormat()
+        {
+            HandHistorySummary expectedSummary = new HandHistorySummary()
+            {
+                GameDescription = new GameDescriptor()
+                {
+                    PokerFormat = PokerFormat.CashGame,
+                    GameType = GameType.NoLimitHoldem,
+                    Limit = Limit.FromSmallBlindBigBlind(0.5m, 1m, Currency.USD),
+                    SeatType = SeatType.FromMaxPlayers(6),
+                    Site = SiteName.GGPoker,
+                    TableType = TableType.FromTableTypeDescriptions(TableTypeDescription.Regular)
+                },
+                DateOfHandUtc = new DateTime(2020, 1, 12, 11, 17, 37),
+                DealerButtonPosition = 6,
+                HandId = HandID.From(1412421),
+                NumPlayersSeated = 6,
+                TableName = "NLHGold3",
+                TotalPot = 2.5m,
+                Rake = 0m,
+                Jackpot = 0m,
+                Bingo = 0
+            };
+
+            HandHistory expectedHandHistory = new HandHistory()
+            {
+                CommunityCards = BoardCards.ForPreflop(),
+                Players = new PlayerList(new List<Player>
+                {
+                    new Player("1476ab3d", 50.5m, 1),
+                    new Player("x413dcda", 17.34m, 2),
+                    new Player("xca591ab", 100m, 3),
+                    new Player("Hero", 78m, 4, HoleCards.FromCards("2c3h")),
+                    new Player("90badc41", 100.28m, 5),
+                    new Player("c32avd12", 5.84m, 6),
+                }),
+                Hero = new Player("Hero", 78m, 4, HoleCards.FromCards("2c3h")),
+                RunItMultipleTimes = new RunItTwice[]
+                {
+                    new RunItTwice
+                    {
+                        Board = null,
+                        Actions = new List<HandAction> { },
+                        Winners = new List<WinningsAction>
+                        {
+                            new WinningsAction("xca591ab", WinningsActionType.WINS, 2.5m, 0),
+                        }
+                    },
+                    new RunItTwice {},
+                    new RunItTwice {}
+                },
+                Winners = new List<WinningsAction>() 
+                { 
+                    new WinningsAction("xca591ab", WinningsActionType.WINS, 2.5m, 0),
+                },
+                HandActions = new List<HandAction>() {
+                    new HandAction("1476ab3d", HandActionType.SMALL_BLIND, -0.5m, Street.Preflop),
+                    new HandAction("x413dcda", HandActionType.BIG_BLIND, -1m, Street.Preflop),
+                    new HandAction("xca591ab", HandActionType.RAISE, 2m, Street.Preflop),
+                    new HandAction("Hero", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("90badc41", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("c32avd12", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("1476ab3d", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("x413dcda", HandActionType.FOLD, 0, Street.Preflop),
+                    new HandAction("xca591ab", HandActionType.UNCALLED_BET, 1m, Street.Preflop),
+                },
+            };
+        
+            TestFullHandHistorySummary(expectedSummary, "NewLimitFormat");
+            TestHandHistory(expectedHandHistory, "NewLImitFormat");
+        }
     }
 }

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/PokerStars/PokerStarsFastParserActionTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/PokerStars/PokerStarsFastParserActionTests.cs
@@ -265,5 +265,21 @@ namespace HandHistories.Parser.UnitTests.Parsers.FastParserTests.PokerStars
 
             Assert.AreEqual(new HandAction("RECHUK", HandActionType.SHOW, 0m, Street.Showdown), handAction);
         }
+
+        [Test]
+        public void ParseLimit_WithTwoConsecutivesSpacesBeforeLimit_Works()
+        {
+            Limit limit = GetPokerStarsFastParser().ParseLimit("Poker Hand #HD3229201: Hold'em No Limit  ($0.5/$1) - 2018/11/08 11:20:15\r\n");
+
+            Assert.AreEqual(Limit.FromSmallBlindBigBlind(0.5m, 1m, Currency.USD), limit);
+        }
+
+        [Test]
+        public void ParseLimit_WithOneSpaceBeforeLimit_Works()
+        {
+            Limit limit = GetPokerStarsFastParser().ParseLimit("Poker Hand #HD3229201: Hold'em No Limit ($0.5/$1) - 2018/11/08 11:20:15\r\n");
+
+            Assert.AreEqual(Limit.FromSmallBlindBigBlind(0.5m, 1m, Currency.USD), limit);
+        }
     }
 }

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/NewLimitFormat.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/GGPoker/CashGame/GeneralHands/NewLimitFormat.txt
@@ -1,0 +1,34 @@
+Poker Hand #HD1412421: Hold'em No Limit ($0.5/$1) - 2020/01/12 11:17:37
+Table 'NLHGold3' 6-max Seat #6 is the button
+Seat 1: 1476ab3d ($50.5 in chips)
+Seat 2: x413dcda ($17.34 in chips)
+Seat 3: xca591ab ($100 in chips)
+Seat 4: Hero ($78 in chips)
+Seat 5: 90badc41 ($100.28 in chips)
+Seat 6: c32avd12 ($5.84 in chips)
+1476ab3d: posts small blind $0.5
+x413dcda: posts big blind $1
+*** HOLE CARDS ***
+Dealt to 1476ab3d 
+Dealt to x413dcda 
+Dealt to xca591ab 
+Dealt to Hero [2c 3h]
+Dealt to 90badc41 
+Dealt to c32avd12 
+xca591ab: raises $1 to $2
+Hero: folds
+90badc41: folds
+c32avd12: folds
+1476ab3d: folds
+x413dcda: folds
+Uncalled bet ($1) returned to xca591ab
+*** SHOWDOWN ***
+xca591ab collected $2.5 from pot
+*** SUMMARY ***
+Total pot $2.5 | Rake $0 | Jackpot $0 | Bingo $0 | Fortune $0 | Tax $0
+Seat 1: 1476ab3d (small blind) folded before Flop
+Seat 2: x413dcda (big blind) folded before Flop
+Seat 3: xca591ab collected ($2.5)
+Seat 4: Hero folded before Flop (didn't bet)
+Seat 5: 90badc41 folded before Flop (didn't bet)
+Seat 6: c32avd12 (button) folded before Flop (didn't bet)

--- a/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/GGPoker/GGPokerFastParserImpl.cs
@@ -394,7 +394,7 @@ namespace HandHistories.Parser.Parsers.FastParser.GGPoker
             // or
 
             // Poker Hand #HD138495: Hold'em No Limit  ($0.5/$1) - 2019/10/12 01:43:27
-            string stake = handLines[0].Split(' ')[7];
+            string stake = handLines[0].Split(' ', StringSplitOptions.RemoveEmptyEntries)[6];
             stake = stake.Substring(1, stake.Length - 2);
             Currency currency = ParseCurrency(handLines[0], stake[0]);
 


### PR DESCRIPTION
In the earlier hand histories,  there are two spaces before the Limit. In the later hand histories, there is only one space. We need make sure the parser handles both.