### PR TITLE
Add PLO6 support

### DIFF
--- a/HandHistories.Objects/Cards/HoleCards.cs
+++ b/HandHistories.Objects/Cards/HoleCards.cs
@@ -44,6 +44,16 @@ namespace HandHistories.Objects.Cards
             return new HoleCards(playerName, card1, card2, card3, card4, card5);
         }
 
+        public static HoleCards ForOmaha6(Card card1, Card card2, Card card3, Card card4, Card card5, Card card6)
+        {
+            return new HoleCards(string.Empty, card1, card2, card3, card4, card5, card6);
+        }
+
+        public static HoleCards ForOmaha6(string playerName, Card card1, Card card2, Card card3, Card card4, Card card5, Card card6)
+        {
+            return new HoleCards(playerName, card1, card2, card3, card4, card5, card6);
+        }
+
         public static HoleCards NoHolecards()
         {
             return new HoleCards(string.Empty);
@@ -74,9 +84,9 @@ namespace HandHistories.Objects.Cards
             {
                 return NoHolecards();
             }
-            if (cards.Length > 5)
+            if (cards.Length > 6)
             {
-                throw new ArgumentException("Hole cards cant contain more than 5 cards.");
+                throw new ArgumentException("Hole cards cant contain more than 6 cards.");
             }
             return new HoleCards(playerName, cards);
         }       

--- a/HandHistories.Objects/GameDescription/GameTypes.Statics.cs
+++ b/HandHistories.Objects/GameDescription/GameTypes.Statics.cs
@@ -134,5 +134,13 @@ namespace HandHistories.Objects.GameDescription
                 return new GameType(GameLimitEnum.PotLimit, GameEnum.FiveCardOmahaHiLo);
             }
         }
+
+        public static GameType SixCardPotLimitOmaha
+        {
+            get
+            {
+                return new GameType(GameLimitEnum.PotLimit, GameEnum.SixCardOmaha);
+            }
+        }
     }
 }

--- a/HandHistories.Objects/GameDescription/GameTypes.cs
+++ b/HandHistories.Objects/GameDescription/GameTypes.cs
@@ -29,6 +29,8 @@ namespace HandHistories.Objects.GameDescription
         [EnumMember]
         FiveCardOmahaHiLo,
         [EnumMember]
+        SixCardOmaha,
+        [EnumMember]
         Any = 255,
     }
 


### PR DESCRIPTION
## Summary
- Add `SixCardOmaha` enum and `SixCardPotLimitOmaha` factory property
- Add `ForOmaha6` hole card factory methods and raise card limit to 6
- No `GameTypeUtils` parse cases added yet — parsing is handled externally and we don't know the PLO6 identifier strings in raw hand histories yet

## Test plan
- [ ] Verify `dotnet build` passes
- [ ] Confirm DriveHud XML parser can map to `GameEnum.SixCardOmaha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)