### PR TITLE
Add PLO6 support

### DIFF
--- a/HandHistories.Objects/Cards/HoleCards.cs
+++ b/HandHistories.Objects/Cards/HoleCards.cs
@@ -44,6 +44,16 @@ namespace HandHistories.Objects.Cards
             return new HoleCards(playerName, card1, card2, card3, card4, card5);
         }
 
+        public static HoleCards ForOmaha6(Card card1, Card card2, Card card3, Card card4, Card card5, Card card6)
+        {
+            return new HoleCards(string.Empty, card1, card2, card3, card4, card5, card6);
+        }
+
+        public static HoleCards ForOmaha6(string playerName, Card card1, Card card2, Card card3, Card card4, Card card5, Card card6)
+        {
+            return new HoleCards(playerName, card1, card2, card3, card4, card5, card6);
+        }
+
         public static HoleCards NoHolecards()
         {
             return new HoleCards(string.Empty);
@@ -74,9 +84,9 @@ namespace HandHistories.Objects.Cards
             {
                 return NoHolecards();
             }
-            if (cards.Length > 5)
+            if (cards.Length > 6)
             {
-                throw new ArgumentException("Hole cards cant contain more than 5 cards.");
+                throw new ArgumentException("Hole cards cant contain more than 6 cards.");
             }
             return new HoleCards(playerName, cards);
         }       

--- a/HandHistories.Objects/GameDescription/GameTypeUtils.cs
+++ b/HandHistories.Objects/GameDescription/GameTypeUtils.cs
@@ -58,6 +58,10 @@ namespace HandHistories.Objects.GameDescription
                 case "pot limit five card omaha":
                 case "5 card omaha pot limit":
                     return GameType.FiveCardPotLimitOmaha;
+                case "omaha6 pot limit":
+                case "pot limit six card omaha":
+                case "6 card omaha pot limit":
+                    return GameType.SixCardPotLimitOmaha;
                 default:
                     string match = Enum.GetNames(typeof(GameType)).FirstOrDefault(g => g.ToLower().Equals(gameString.ToLower()));
                     return match == null ? GameType.Unknown : (GameType)Enum.Parse(typeof(GameType), match,true);

--- a/HandHistories.Objects/GameDescription/GameTypes.Statics.cs
+++ b/HandHistories.Objects/GameDescription/GameTypes.Statics.cs
@@ -134,5 +134,13 @@ namespace HandHistories.Objects.GameDescription
                 return new GameType(GameLimitEnum.PotLimit, GameEnum.FiveCardOmahaHiLo);
             }
         }
+
+        public static GameType SixCardPotLimitOmaha
+        {
+            get
+            {
+                return new GameType(GameLimitEnum.PotLimit, GameEnum.SixCardOmaha);
+            }
+        }
     }
 }

--- a/HandHistories.Objects/GameDescription/GameTypes.cs
+++ b/HandHistories.Objects/GameDescription/GameTypes.cs
@@ -29,6 +29,8 @@ namespace HandHistories.Objects.GameDescription
         [EnumMember]
         FiveCardOmahaHiLo,
         [EnumMember]
+        SixCardOmaha,
+        [EnumMember]
         Any = 255,
     }
 


### PR DESCRIPTION
## Summary
- Add PLO6 (pot-limit six-card Omaha) support to HandHistories.Objects
- Only pot-limit variant included as that's the only one currently played

## Test plan
- [ ] `dotnet build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)