### PR TITLE
Add showdown status and card-reveal action to parsed hands

### DIFF
--- a/HandHistories.Objects.UnitTests/HandHistories.Objects.UnitTests.csproj
+++ b/HandHistories.Objects.UnitTests/HandHistories.Objects.UnitTests.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!--
+      Test projects target net8.0 (while production libraries stay on netstandard2.0/2.1
+      so downstream consumers are unaffected). .NET Core 3.1 is EOL (Dec 2022) and has no
+      native arm64 build, so the previous netcoreapp3.1 target couldn't run on Apple Silicon
+      without installing the x64 runtime under Rosetta 2. net8.0 runs natively everywhere.
+    -->
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HandHistories.Objects/Cards/RevealAction.cs
+++ b/HandHistories.Objects/Cards/RevealAction.cs
@@ -1,0 +1,38 @@
+namespace HandHistories.Objects.Cards
+{
+    /// <summary>
+    /// What the rest of the table saw a player do with their hole cards.
+    /// Orthogonal to whether the parser has the cards (<see cref="Players.Player.HoleCards"/>)
+    /// and to whether the player is the hero (<see cref="Hand.HandHistory.Hero"/>).
+    /// <para>
+    /// Reveal values (<see cref="ShownAtShowdown"/>, <see cref="ShownVoluntarily"/>) do not
+    /// guarantee that *all* hole cards were exposed. In Omaha variants (4/5/6 hole cards) and
+    /// hi/lo split games, a player may reveal only a subset. Compare
+    /// <c>Player.HoleCards.Count</c> against the expected count for
+    /// <c>GameDescription.GameType</c> to detect a partial reveal.
+    /// </para>
+    /// </summary>
+    public enum RevealAction
+    {
+        /// <summary>Cards never shown to the table (folded early, or silent muck).</summary>
+        NotShown = 0,
+
+        /// <summary>
+        /// Player reached showdown and explicitly mucked. Cards may still leak to
+        /// the parser via summary lines on some sites, but the table didn't see them.
+        /// </summary>
+        MuckedAtShowdown = 1,
+
+        /// <summary>
+        /// Revealed at showdown — hand reached the showdown phase.
+        /// Reveal may be partial (see type-level remarks).
+        /// </summary>
+        ShownAtShowdown = 2,
+
+        /// <summary>
+        /// Revealed voluntarily after winning uncontested (winner flashed).
+        /// Reveal may be partial (see type-level remarks).
+        /// </summary>
+        ShownVoluntarily = 3,
+    }
+}

--- a/HandHistories.Objects/Hand/HandHistory.cs
+++ b/HandHistories.Objects/Hand/HandHistory.cs
@@ -35,7 +35,13 @@ namespace HandHistories.Objects.Hand
 
         public Player Hero { get; set; }
 
-        public RunItTwice RunItTwiceData { get; set;  } 
+        /// <summary>
+        /// True iff the hand reached the showdown phase with at least two players
+        /// still live (i.e. fewer than <c>Players.Count - 1</c> players folded).
+        /// </summary>
+        public bool WentToShowdown { get; set; }
+
+        public RunItTwice RunItTwiceData { get; set;  }
         
         public RunItTwice[] RunItMultipleTimes { get; set;  }
 

--- a/HandHistories.Objects/Hand/HandHistory.cs
+++ b/HandHistories.Objects/Hand/HandHistory.cs
@@ -36,7 +36,7 @@ namespace HandHistories.Objects.Hand
         public Player Hero { get; set; }
 
         /// <summary>
-        /// True iff the hand reached the showdown phase with at least two players
+        /// True if the hand reached the showdown phase with at least two players
         /// still live (i.e. fewer than <c>Players.Count - 1</c> players folded).
         /// </summary>
         public bool WentToShowdown { get; set; }

--- a/HandHistories.Objects/Players/Player.cs
+++ b/HandHistories.Objects/Players/Player.cs
@@ -28,6 +28,14 @@ namespace HandHistories.Objects.Players
         [DataMember]
         public bool IsSittingOut { get; set; }
 
+        /// <summary>
+        /// What the rest of the table saw this player do with their hole cards.
+        /// Independent of <see cref="HoleCards"/> (which answers whether the parser
+        /// has the cards) and of whether this player is the hero.
+        /// </summary>
+        [DataMember]
+        public RevealAction RevealAction { get; set; }
+
         public Player(string playerName, 
                       decimal startingStack,
                       int seatNumber)

--- a/HandHistories.Parser.UnitTests/Analyzers/ShowdownAnalyzerTests.cs
+++ b/HandHistories.Parser.UnitTests/Analyzers/ShowdownAnalyzerTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using HandHistories.Objects.Actions;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.Hand;
+using HandHistories.Objects.Players;
+using HandHistories.Parser.Analyzers;
+using NUnit.Framework;
+
+namespace HandHistories.Parser.UnitTests.Analyzers
+{
+    [TestFixture]
+    public class ShowdownAnalyzerTests
+    {
+        private static Player P(string name, int seat) => new Player(name, 100m, seat);
+
+        private static HandHistory HandWith(IEnumerable<Player> players, IEnumerable<HandAction> actions)
+        {
+            var hand = new HandHistory();
+            foreach (var p in players) hand.Players.Add(p);
+            hand.HandActions = new List<HandAction>(actions);
+            return hand;
+        }
+
+        [Test]
+        public void HeadsUpShowdown_BothShow_BothAreShownAtShowdown()
+        {
+            var hero = P("Hero", 1);
+            var villain = P("Villain", 2);
+            hero.HoleCards = HoleCards.FromCards("AsKs");
+            villain.HoleCards = HoleCards.FromCards("QhQd");
+
+            var hand = HandWith(new[] { hero, villain }, new[]
+            {
+                new HandAction("Hero", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
+                new HandAction("Villain", HandActionType.BIG_BLIND, 1m, Street.Preflop),
+                new HandAction("Hero", HandActionType.CALL, 0.5m, Street.Preflop),
+                new HandAction("Villain", HandActionType.CHECK, 0m, Street.Preflop),
+                new HandAction("Hero", HandActionType.SHOW, 0m, Street.Showdown),
+                new HandAction("Villain", HandActionType.SHOW, 0m, Street.Showdown),
+            });
+            hand.Hero = hero;
+
+            ShowdownAnalyzer.Populate(hand);
+
+            Assert.IsTrue(hand.WentToShowdown);
+            Assert.AreEqual(RevealAction.ShownAtShowdown, hero.RevealAction);
+            Assert.AreEqual(RevealAction.ShownAtShowdown, villain.RevealAction);
+        }
+
+        [Test]
+        public void EveryoneFoldsPreflop_NoShowdown_HeroStillHasCards()
+        {
+            var hero = P("Hero", 1);
+            var v1 = P("V1", 2);
+            var v2 = P("V2", 3);
+            hero.HoleCards = HoleCards.FromCards("7c2d"); // from "Dealt to" line
+
+            var hand = HandWith(new[] { hero, v1, v2 }, new[]
+            {
+                new HandAction("Hero", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
+                new HandAction("V1", HandActionType.BIG_BLIND, 1m, Street.Preflop),
+                new HandAction("V2", HandActionType.FOLD, 0m, Street.Preflop),
+                new HandAction("Hero", HandActionType.FOLD, 0m, Street.Preflop),
+            });
+            hand.Hero = hero;
+
+            ShowdownAnalyzer.Populate(hand);
+
+            Assert.IsFalse(hand.WentToShowdown);
+            Assert.AreEqual(RevealAction.NotShown, hero.RevealAction);
+            Assert.IsNotNull(hero.HoleCards, "Hero cards stay known even though not shown to the table.");
+            Assert.AreEqual(RevealAction.NotShown, v1.RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, v2.RevealAction);
+        }
+
+        [Test]
+        public void UncontestedWinnerFlashes_IsShownVoluntarily()
+        {
+            var hero = P("Hero", 1);
+            var villain = P("Villain", 2);
+            hero.HoleCards = HoleCards.FromCards("AsAh");
+
+            var hand = HandWith(new[] { hero, villain }, new[]
+            {
+                new HandAction("Hero", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
+                new HandAction("Villain", HandActionType.BIG_BLIND, 1m, Street.Preflop),
+                new HandAction("Hero", HandActionType.RAISE, 3m, Street.Preflop),
+                new HandAction("Villain", HandActionType.FOLD, 0m, Street.Preflop),
+                new HandAction("Hero", HandActionType.SHOW, 0m, Street.Preflop),
+            });
+            hand.Hero = hero;
+
+            ShowdownAnalyzer.Populate(hand);
+
+            Assert.IsFalse(hand.WentToShowdown);
+            Assert.AreEqual(RevealAction.ShownVoluntarily, hero.RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, villain.RevealAction);
+        }
+
+        [Test]
+        public void MucksAtShowdown_ButCardsLeakedInSummary_IsMuckedAtShowdown()
+        {
+            var hero = P("Hero", 1);
+            var villain = P("Villain", 2);
+            hero.HoleCards = HoleCards.FromCards("QcJc");          // from "Dealt to"
+            villain.HoleCards = HoleCards.FromCards("AhKh");       // from "shows"
+
+            var hand = HandWith(new[] { hero, villain }, new[]
+            {
+                new HandAction("Hero", HandActionType.SMALL_BLIND, 0.5m, Street.Preflop),
+                new HandAction("Villain", HandActionType.BIG_BLIND, 1m, Street.Preflop),
+                new HandAction("Hero", HandActionType.CALL, 0.5m, Street.Preflop),
+                new HandAction("Villain", HandActionType.CHECK, 0m, Street.Preflop),
+                new HandAction("Villain", HandActionType.SHOW, 0m, Street.Showdown),
+                new HandAction("Hero", HandActionType.MUCKS, 0m, Street.Showdown),
+            });
+            hand.Hero = hero;
+
+            ShowdownAnalyzer.Populate(hand);
+
+            Assert.IsTrue(hand.WentToShowdown);
+            Assert.AreEqual(RevealAction.MuckedAtShowdown, hero.RevealAction);
+            Assert.IsNotNull(hero.HoleCards, "Mucked hero cards leaked via summary must remain accessible.");
+            Assert.AreEqual(RevealAction.ShownAtShowdown, villain.RevealAction);
+        }
+
+        [Test]
+        public void NullHandOrMissingParts_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => ShowdownAnalyzer.Populate(null));
+
+            var hand = new HandHistory();
+            hand.HandActions = null;
+            Assert.DoesNotThrow(() => ShowdownAnalyzer.Populate(hand));
+        }
+    }
+}

--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1,7 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!--
+      Test projects target net8.0 (while production libraries stay on netstandard2.0/2.1
+      so downstream consumers are unaffected). .NET Core 3.1 is EOL (Dec 2022) and has no
+      native arm64 build, so the previous netcoreapp3.1 target couldn't run on Apple Silicon
+      without installing the x64 runtime under Rosetta 2. net8.0 runs natively everywhere.
+    -->
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HandHistories.Parser.UnitTests/Parsers/Base/SampleHandHistoryRepositoryFileBasedImpl.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/Base/SampleHandHistoryRepositoryFileBasedImpl.cs
@@ -97,7 +97,10 @@ namespace HandHistories.Parser.UnitTests.Parsers.Base
 
         private string GetSampleHandHistoryFolder(PokerFormat pokerFormat, SiteName siteName)
         {
-            return string.Format(@"SampleHandHistories\{0}\{1}\", siteName, pokerFormat);
+            // Use Path.Combine for cross-platform separators; the previous hard-coded
+            // "\" broke every file lookup on macOS/Linux, causing NullReferenceException
+            // in callers that Split the returned text.
+            return System.IO.Path.Combine("SampleHandHistories", siteName.ToString(), pokerFormat.ToString());
         }
     }
 }

--- a/HandHistories.Parser/Analyzers/ShowdownAnalyzer.cs
+++ b/HandHistories.Parser/Analyzers/ShowdownAnalyzer.cs
@@ -8,7 +8,7 @@ namespace HandHistories.Parser.Analyzers
     /// <summary>
     /// Post-parse pass that populates <see cref="HandHistory.WentToShowdown"/> and
     /// each <see cref="Objects.Players.Player.RevealAction"/> from the already-parsed
-    /// action list. Runs once per hand; derivation is a single linear walk.
+    /// action list.
     /// </summary>
     public static class ShowdownAnalyzer
     {

--- a/HandHistories.Parser/Analyzers/ShowdownAnalyzer.cs
+++ b/HandHistories.Parser/Analyzers/ShowdownAnalyzer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using HandHistories.Objects.Actions;
+using HandHistories.Objects.Cards;
+using HandHistories.Objects.Hand;
+
+namespace HandHistories.Parser.Analyzers
+{
+    /// <summary>
+    /// Post-parse pass that populates <see cref="HandHistory.WentToShowdown"/> and
+    /// each <see cref="Objects.Players.Player.RevealAction"/> from the already-parsed
+    /// action list. Runs once per hand; derivation is a single linear walk.
+    /// </summary>
+    public static class ShowdownAnalyzer
+    {
+        public static void Populate(HandHistory hand)
+        {
+            if (hand == null || hand.Players == null || hand.HandActions == null)
+            {
+                return;
+            }
+
+            var folded = new HashSet<string>();
+            var shown = new HashSet<string>();
+            var mucked = new HashSet<string>();
+
+            foreach (var action in hand.HandActions)
+            {
+                switch (action.HandActionType)
+                {
+                    case HandActionType.FOLD:
+                        folded.Add(action.PlayerName);
+                        break;
+                    case HandActionType.SHOW:
+                    case HandActionType.SHOWS_FOR_LOW:
+                        shown.Add(action.PlayerName);
+                        break;
+                    case HandActionType.MUCKS:
+                        mucked.Add(action.PlayerName);
+                        break;
+                }
+            }
+
+            int liveAtEnd = hand.Players.Count - folded.Count;
+            hand.WentToShowdown = liveAtEnd >= 2;
+
+            foreach (var player in hand.Players)
+            {
+                if (shown.Contains(player.PlayerName))
+                {
+                    player.RevealAction = hand.WentToShowdown
+                        ? RevealAction.ShownAtShowdown
+                        : RevealAction.ShownVoluntarily;
+                }
+                else if (mucked.Contains(player.PlayerName))
+                {
+                    player.RevealAction = RevealAction.MuckedAtShowdown;
+                }
+                else
+                {
+                    player.RevealAction = RevealAction.NotShown;
+                }
+            }
+        }
+    }
+}

--- a/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
@@ -3,6 +3,7 @@ using HandHistories.Objects.Cards;
 using HandHistories.Objects.GameDescription;
 using HandHistories.Objects.Hand;
 using HandHistories.Objects.Players;
+using HandHistories.Parser.Analyzers;
 using HandHistories.Parser.Parsers.Base;
 using HandHistories.Parser.Parsers.Exceptions;
 using HandHistories.Parser.Utils.AllInAction;
@@ -256,6 +257,8 @@ namespace HandHistories.Parser.Parsers.FastParser.Base
                 }
 
                 FinalizeHandHistory(handHistory);
+
+                ShowdownAnalyzer.Populate(handHistory);
 
                 SetActionNumbers(handHistory);
 


### PR DESCRIPTION
## Summary

Surfaces two new properties on every parsed hand, derived once in a post-parse pass so no site parser needs to change:

- **`HandHistory.WentToShowdown`** (`bool`) — true iff the hand reached showdown with at least two players still live.
- **`Player.RevealAction`** (enum: `NotShown` / `MuckedAtShowdown` / `ShownAtShowdown` / `ShownVoluntarily`) — what the rest of the table saw this player do with their hole cards.

## Why

Until now, `Player.HoleCards` was a single nullable slot that parsers overwrote regardless of *how* the cards became known — dealt to hero, shown voluntarily, forced at showdown, or leaked via `mucked [cards]` in summary. Consumers couldn't distinguish a hero's dealt cards from a villain's showdown reveal, and had no convenience flag for WTSD.

The three facts are kept on orthogonal axes by design:

| Question | Answered by |
| --- | --- |
| Does the parser have the cards? | `Player.HoleCards != null` |
| Is this player the hero? | `HandHistory.Hero` |
| What did the table see? | `Player.RevealAction` (new) |

So a hero who reaches showdown and turns over cleanly gets `RevealAction.ShownAtShowdown` (table-visibility) without losing the fact that `HoleCards` was set from the "Dealt to" line (parser-knowledge).

Reveal values may be partial in Omaha / hi-lo split games (a player shows only some of 4/5/6 hole cards). This is documented on the enum; callers detect it by comparing `HoleCards.Count` against the expected count for `GameDescription.GameType`.

## Implementation

- `HandHistories.Objects/Cards/RevealAction.cs` — new enum with XML docs.
- `HandHistories.Objects/Players/Player.cs` — new `RevealAction` property (defaults to `NotShown`).
- `HandHistories.Objects/Hand/HandHistory.cs` — new `WentToShowdown` property (defaults to `false`).
- `HandHistories.Parser/Analyzers/ShowdownAnalyzer.cs` — single linear walk of `HandActions` to populate both.
- `HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs` — invokes the analyzer right after `FinalizeHandHistory` in `ParseFullHandHistory`, so every site parser inherits the behaviour.

## Test-infra fixes bundled in (required to run the suite on macOS)

These are small but worth flagging so reviewers know why they're in this PR:

- **Retargeted both unit-test projects from `netcoreapp3.1` to `net8.0`.** .NET Core 3.1 is EOL (Dec 2022) with no native arm64 build, so the previous target couldn't run on Apple Silicon without x64 + Rosetta 2. Production libraries stay on `netstandard2.0` / `netstandard2.1` — downstream consumers unaffected. Rationale is inlined in both csproj files.
- **Fixed a hard-coded `\` path separator** in `SampleHandHistoryRepositoryFileBasedImpl.GetSampleHandHistoryFolder` with `Path.Combine`. The old code returned `null` on unix filesystems, cascading into ~700 `NullReferenceException`s in tests that split the result.

After these fixes the suite goes from unrunnable on macOS → **994 passing / 27 failing**. The remaining 27 failures are pre-existing cross-platform issues (Windows-1252 sample-file encoding read as UTF-8, and `\r\n`-only line splits on LF checkouts) and are unrelated to this change.

## Test plan

- [x] New `ShowdownAnalyzerTests` (5 tests) covers every enum value, the `WentToShowdown` flag, and the mucked-but-leaked-in-summary case — all pass.
- [x] Full suite runs on macOS (net8.0): 994 passing / 27 pre-existing failures unrelated to this PR.
- [ ] CI / Windows run to confirm no regressions on the maintainer's primary platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)