### PR TITLE
Fix cross-platform test-suite failures on macOS/Linux

### DIFF
--- a/HandHistories.Objects/GameDescription/Limit.cs
+++ b/HandHistories.Objects/GameDescription/Limit.cs
@@ -1,4 +1,4 @@
-using System;
+ï»¿using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 
@@ -53,15 +53,15 @@ namespace HandHistories.Objects.GameDescription
                 case Currency.USD:
                     return @"$";
                 case Currency.EURO:
-                    return @"€";
+                    return @"â‚¬";
                 case Currency.GBP:
-                    return @"£";
+                    return @"Â£";
                 case Currency.SEK:
                     return "SEK";
                 case Currency.CHIPS:
                     return "";
                 case Currency.CNY:
-                    return @"¥";
+                    return @"Â¥";
                 case Currency.All:
                     return @"";
                 default:

--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Ninject" Version="3.3.4" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HandHistories.Parser.UnitTests/Parsers/Base/SampleHandHistoryRepositoryFileBasedImpl.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/Base/SampleHandHistoryRepositoryFileBasedImpl.cs
@@ -3,11 +3,25 @@ using HandHistories.Objects.Cards;
 using HandHistories.Objects.GameDescription;
 using HandHistories.Parser.UnitTests.Utils.IO;
 using System;
+using System.IO;
 
 namespace HandHistories.Parser.UnitTests.Parsers.Base
 {
     internal class SampleHandHistoryRepositoryFileBasedImpl : ISampleHandHistoryRepository
     {
+        private static readonly Encoding StrictUtf8 = Encoding.GetEncoding(
+            Encoding.UTF8.WebName,
+            EncoderFallback.ExceptionFallback,
+            DecoderFallback.ExceptionFallback);
+
+        private static readonly Encoding Windows1252 = GetWindows1252();
+
+        private static Encoding GetWindows1252()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            return Encoding.GetEncoding(1252);
+        }
+
         private readonly IFileReader _fileReader;
         private readonly string _version;
 
@@ -92,7 +106,29 @@ namespace HandHistories.Parser.UnitTests.Parsers.Base
                 return null;
             }
 
-            return _fileReader.ReadAllText(path, Encoding.UTF8);
+            return ReadSampleFile(path);
+        }
+
+        private static string ReadSampleFile(string path)
+        {
+            byte[] bytes = File.ReadAllBytes(path);
+
+            int start = 0;
+            int length = bytes.Length;
+            if (length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            {
+                start = 3;
+                length -= 3;
+            }
+
+            try
+            {
+                return StrictUtf8.GetString(bytes, start, length);
+            }
+            catch (DecoderFallbackException)
+            {
+                return Windows1252.GetString(bytes, start, length);
+            }
         }
 
         private string GetSampleHandHistoryFolder(PokerFormat pokerFormat, SiteName siteName)

--- a/HandHistories.Parser.UnitTests/Parsers/ThreeStateParserTests/ThreeStateParserTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/ThreeStateParserTests/ThreeStateParserTests.cs
@@ -51,7 +51,7 @@ namespace HandHistories.Parser.UnitTests.Parsers.ThreeStateParserTests
         string[] GetTest(string test, string name)
         {
             return SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, test, name)
-                .Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         protected abstract List<HandAction> ExpectedHandActionsAnte { get; }

--- a/HandHistories.Parser/Parsers/JSONParser/Base/HandHistoryParserJSONImpl.cs
+++ b/HandHistories.Parser/Parsers/JSONParser/Base/HandHistoryParserJSONImpl.cs
@@ -21,7 +21,7 @@ namespace HandHistories.Parser.Parsers.JSONParser.Base
 {
     public abstract class HandHistoryParserJSONImpl : IHandHistoryParser
     {
-        private static readonly Regex HandSplitRegex = new Regex("\r\n\r\n", RegexOptions.Compiled);
+        private static readonly Regex HandSplitRegex = new Regex("\r?\n\r?\n", RegexOptions.Compiled);
 
         public abstract SiteName SiteName { get; }
 


### PR DESCRIPTION
## Summary

Four fixes that together let the .NET test suite build and run cleanly on macOS/Linux without touching sample-file contents. On Windows (CRLF checkout, system code page 1252) behavior is unchanged.

- **`680195b` — `ThreeStateParserTests` line-ending split.** `GetTest` split on the literal `"\r\n"`, so on LF checkouts the blind- and showdown-action tests fed the parser one unsplittable blob. Now splits on the `'\r'` and `'\n'` characters, matching what `HandHistoryParserFastImpl` already does.
- **`1e8a08b` — Encoding-aware sample-file reader.** `SampleHandHistoryRepositoryFileBasedImpl` previously hard-coded `Encoding.UTF8`, so hand-history files produced by the Windows-only Winamax and MicroGaming clients (cp1252) were silently mangled. Prefer strict UTF-8, fall back to Windows-1252 on invalid-UTF-8 bytes. Fixtures stay byte-for-byte copies of real client output; future cp1252 captures no longer need manual conversion. Adds `System.Text.Encoding.CodePages` because .NET Core dropped Windows-1252 from the default encoding set.
- **`76fd549` — Re-encode `HandHistories.Objects/GameDescription/Limit.cs` as UTF-8 with BOM.** The source file held three currency symbols as raw Windows-1252 bytes (`0x80` €, `0xA3` £, `0xA5` ¥) with no BOM. Roslyn on Windows falls back to the system code page and compiles them correctly; on macOS/Linux the compiler treats the file as UTF-8, hits invalid start bytes, and replaces each with `U+FFFD`. The shipped assembly emits `�` everywhere it should emit `€/£/¥`, which is the actual root cause of the limit / currency-symbol test failures on non-Windows hosts. No semantic change — the encoded code points (U+20AC, U+00A3, U+00A5) are what the tests and downstream consumers already expect.
- **`ec99491` — JSON hand splitter LF tolerance.** `HandHistoryParserJSONImpl.SplitUpMultipleHands` split on the literal `"\r\n\r\n"`, so an LF-only multi-hand JSON dump (produced on macOS/Linux, or by any tool that doesn't emit CRLF) was treated as one giant hand. Relaxed to `"\r?\n\r?\n"`, matching the fast-parser base class.

## Test plan

- [x] `dotnet test HandHistories.Parser.UnitTests` on macOS (LF checkout, net8.0): **Passed: 1021, Failed: 0, Skipped: 386**.
- [ ] Run the same on Windows (CRLF checkout) — expect no regressions. The Windows compiler already read `Limit.cs` correctly via the cp1252 fallback, so re-encoding to UTF-8 with BOM is a no-op for that toolchain.
- [ ] Spot-check one Winamax and one MicroGaming sample still parses: the cp1252 bytes are unchanged on disk, the harness now decodes them correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)