### PR TITLE
Emit synthetic SHOW actions for summary-only card reveals

### DIFF
--- a/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
+++ b/HandHistories.Parser.UnitTests/HandHistories.Parser.UnitTests.csproj
@@ -1320,6 +1320,9 @@
     <None Update="SampleHandHistories\PokerStars\CashGame\ExtraHands\TableNameWithDash.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="SampleHandHistories\PokerStars\CashGame\ExtraHands\UncontestedWinnerFlash.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="SampleHandHistories\PokerStars\CashGame\ExtraHands\ZoomHand.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/HandHistories.Parser.UnitTests/Parsers/FastParserTests/PokerStars/PokerStarsFastParserActionTests.cs
+++ b/HandHistories.Parser.UnitTests/Parsers/FastParserTests/PokerStars/PokerStarsFastParserActionTests.cs
@@ -345,5 +345,34 @@ Total pot $50.00 | Rake $2.50";
             Assert.IsFalse(handHistory.Players["11856112"].hasHoleCards, "Player 11856112 should not have hole cards");
             Assert.IsFalse(handHistory.Players["11270058"].hasHoleCards, "Player 11270058 should not have hole cards");
         }
+
+        [Test]
+        public void PPPokerShowdownHand_RevealActionsDerivedFromSummary()
+        {
+            var parser = new PokerStarsFastParserImpl(SiteName.PPPoker);
+            string pppokerHand = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "PPPoker", "ShowdownHand");
+
+            var handHistory = parser.ParseFullHandHistory(pppokerHand);
+
+            Assert.IsTrue(handHistory.WentToShowdown, "Two players reached showdown");
+            Assert.AreEqual(RevealAction.ShownAtShowdown, handHistory.Players["11641651"].RevealAction);
+            Assert.AreEqual(RevealAction.ShownAtShowdown, handHistory.Players["10284118"].RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, handHistory.Players["11856112"].RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, handHistory.Players["11270058"].RevealAction);
+        }
+
+        [Test]
+        public void UncontestedWinnerFlash_RevealsAsShownVoluntarily()
+        {
+            var parser = new PokerStarsFastParserImpl();
+            string handText = SampleHandHistoryRepository.GetHandExample(PokerFormat.CashGame, Site, "ExtraHands", "UncontestedWinnerFlash");
+
+            var handHistory = parser.ParseFullHandHistory(handText);
+
+            Assert.IsFalse(handHistory.WentToShowdown, "Both opponents folded preflop");
+            Assert.AreEqual(RevealAction.ShownVoluntarily, handHistory.Players["HeroFlash"].RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, handHistory.Players["VictimSB"].RevealAction);
+            Assert.AreEqual(RevealAction.NotShown, handHistory.Players["VictimBB"].RevealAction);
+        }
     }
 }

--- a/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/ExtraHands/UncontestedWinnerFlash.txt
+++ b/HandHistories.Parser.UnitTests/SampleHandHistories/PokerStars/CashGame/ExtraHands/UncontestedWinnerFlash.txt
@@ -1,0 +1,19 @@
+PokerStars Game #999000000001:  Hold'em No Limit ($0.05/$0.10 USD) - 2026/04/26 12:00:00 ET
+Table 'FlashTest 1' 6-max Seat #1 is the button
+Seat 1: HeroFlash ($10 in chips)
+Seat 2: VictimSB ($10 in chips)
+Seat 3: VictimBB ($10 in chips)
+VictimSB: posts small blind $0.05
+VictimBB: posts big blind $0.10
+*** HOLE CARDS ***
+Dealt to HeroFlash [As Ah]
+HeroFlash: raises $0.30 to $0.40
+VictimSB: folds
+VictimBB: folds
+Uncalled bet ($0.30) returned to HeroFlash
+HeroFlash collected $0.20 from pot
+*** SUMMARY ***
+Total pot $0.20 | Rake $0
+Seat 1: HeroFlash (button) showed [As Ah] and won ($0.20) with a pair of Aces
+Seat 2: VictimSB (small blind) folded before Flop
+Seat 3: VictimBB (big blind) folded before Flop

--- a/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/Base/HandHistoryParserFastImpl.cs
@@ -140,6 +140,14 @@ namespace HandHistories.Parser.Parsers.FastParser.Base
         {
         }
 
+        // Hook for sites whose action stream omits SHOW/MUCKS for cards that surface
+        // only in the SUMMARY block (e.g. PokerStars uncontested-winner flashes,
+        // PPPoker showdowns). Implementations append synthetic HandActions to
+        // hand.HandActions before ShowdownAnalyzer runs.
+        protected virtual void EmitSummaryShowdownActions(string[] handLines, HandHistory hand)
+        {
+        }
+
         public HandHistory ParseFullHandHistory(string handText, bool rethrowExceptions = false)
         {
             try
@@ -257,6 +265,8 @@ namespace HandHistories.Parser.Parsers.FastParser.Base
                 }
 
                 FinalizeHandHistory(handHistory);
+
+                EmitSummaryShowdownActions(handLines, handHistory);
 
                 ShowdownAnalyzer.Populate(handHistory);
 

--- a/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
+++ b/HandHistories.Parser/Parsers/FastParser/PokerStars/PokerStarsFastParserImpl.cs
@@ -1476,6 +1476,94 @@ namespace HandHistories.Parser.Parsers.FastParser.PokerStars
             return playerList;
         }
 
+        // PokerStars (and PPPoker via this same parser) sometimes reveal cards only in
+        // the SUMMARY block: an uncontested winner who flashes ("Seat X: name (button)
+        // showed [..]" with no *** SHOW DOWN *** section), or a PPPoker showdown whose
+        // SHOW DOWN section contains only a collection line. ParseMiscShowdownLine never
+        // sees those lines, so the action stream is missing a SHOW. Append a synthetic
+        // one so ShowdownAnalyzer can derive RevealAction without a side channel.
+        protected override void EmitSummaryShowdownActions(string[] handLines, HandHistory hand)
+        {
+            if (hand?.HandActions == null || handLines == null || handLines.Length == 0)
+            {
+                return;
+            }
+
+            int summaryIndex = GetSummaryStartIndex(handLines, 0);
+            if (summaryIndex == -1)
+            {
+                return;
+            }
+
+            int showDownIndex = GetShowDownStartIndex(handLines, 0, summaryIndex);
+            bool isPPPokerHand = handLines[0].StartsWithFast("PPPoker Hand #");
+
+            var alreadyShown = new HashSet<string>(hand.HandActions
+                .Where(a => a.HandActionType == HandActionType.SHOW || a.HandActionType == HandActionType.SHOWS_FOR_LOW)
+                .Select(a => a.PlayerName));
+
+            // PokerStars uncontested-winner flash: no SHOW DOWN section but summary
+            // "Seat X: name [(position)] showed [..]" reveals cards. Analyzer maps
+            // SHOW + !WentToShowdown → ShownVoluntarily.
+            if (showDownIndex == -1 && !isPPPokerHand)
+            {
+                for (int i = summaryIndex; i < handLines.Length; i++)
+                {
+                    string line = handLines[i];
+                    if (!line.Contains("showed ["))
+                    {
+                        continue;
+                    }
+
+                    int nameExtraOffset = 0;
+                    switch (line)
+                    {
+                        case string s when s.Contains("(button) "):
+                            nameExtraOffset = 9;
+                            break;
+                        case string s when s.Contains("(big blind) "):
+                            nameExtraOffset = 12;
+                            break;
+                        case string s when s.Contains("(small blind) "):
+                            nameExtraOffset = 14;
+                            break;
+                    }
+
+                    int nameStart = line.IndexOfFast(": ") + 2;
+                    int nameEnd = line.IndexOfFast("showed [") - 1 - nameExtraOffset;
+                    string name = line.Substring(nameStart, nameEnd - nameStart);
+
+                    if (alreadyShown.Add(name))
+                    {
+                        hand.HandActions.Add(new HandAction(name, HandActionType.SHOW, Street.Showdown));
+                    }
+                }
+            }
+
+            // PPPoker showdown reveal: cards only in summary as "Seat X: id showed [..]".
+            // Analyzer maps SHOW + WentToShowdown → ShownAtShowdown.
+            if (isPPPokerHand)
+            {
+                for (int i = summaryIndex; i < handLines.Length; i++)
+                {
+                    string line = handLines[i];
+                    if (!line.StartsWithFast("Seat ") || !line.Contains("showed ["))
+                    {
+                        continue;
+                    }
+
+                    int nameStart = line.IndexOfFast(": ") + 2;
+                    int spaceAfterName = line.IndexOfFast(" ", nameStart);
+                    string name = line.Substring(nameStart, spaceAfterName - nameStart);
+
+                    if (alreadyShown.Add(name))
+                    {
+                        hand.HandActions.Add(new HandAction(name, HandActionType.SHOW, Street.Showdown));
+                    }
+                }
+            }
+        }
+
         private int GetDealtToHeroLineIndex(string[] handLines, int lastLineRead)
         {
             for (int i = lastLineRead; i < handLines.Length; i++)


### PR DESCRIPTION
## Summary

- Restores `ShowdownAnalyzer`'s contract from #105 (the action stream is the single source of truth for `WentToShowdown` and `Player.RevealAction`) by closing two gaps via the action stream itself instead of a side channel on `Player`.
- New `EmitSummaryShowdownActions(handLines, hand)` virtual hook on `HandHistoryParserFastImpl`, called between `FinalizeHandHistory` and `ShowdownAnalyzer.Populate`. Default no-op.
- PokerStars override appends a synthetic `HandAction(name, SHOW, Street.Showdown)` for two cases the action stream otherwise misses:
  - **PokerStars uncontested-winner flash** — summary `Seat X: name (button) showed [..]` with no `*** SHOW DOWN ***` section. Analyzer derives `ShownVoluntarily` (because `WentToShowdown == false`).
  - **PPPoker showdown** — `*** SHOW DOWN ***` contains only the collection line; cards appear exclusively in summary `Seat X: id showed [..]`. Analyzer derives `ShownAtShowdown` (because `WentToShowdown == true`).
- `HashSet` guard prevents double-emission when a real SHOW already exists.
- Mucked-summary case is intentionally not handled here — every `Seat X: name mucked [..]` is already paired with a `name: mucks hand` line inside SHOW DOWN that emits a real `MUCKS` via `ParseMiscShowdownLine`.

## Why not pre-set `RevealAction` on `Player` directly?

That alternative was attempted locally and discarded. It (a) breaks #105's "analyzer derives everything from the action stream" contract, (b) labels PPPoker reveals as `ShownVoluntarily` because the analyzer's `WentToShowdown ? ShownAtShowdown : ShownVoluntarily` mapping never runs when `RevealAction` is already set, and (c) requires a new `else: keep` branch on the analyzer. Emitting the missing actions instead lets the analyzer keep its single-source-of-truth model and gets the PPPoker label right for free.

## Test plan

- [x] New integration test `PPPokerShowdownHand_RevealActionsDerivedFromSummary` — exercises the existing `ShowdownHand.txt` fixture; asserts both showing players get `ShownAtShowdown` (the value the discarded approach got wrong).
- [x] New integration test `UncontestedWinnerFlash_RevealsAsShownVoluntarily` — uses a new minimal fixture (`ExtraHands/UncontestedWinnerFlash.txt`); asserts the flasher gets `ShownVoluntarily` and `WentToShowdown` is `false`.
- [x] Full `HandHistories.Parser.UnitTests` suite on macOS: 1023 passed / 0 failed / 386 skipped (skips are pre-existing platform-conditional). Up from the post-#105 baseline of 994 / 27.
- [x] `HandHistories.Objects.UnitTests`: 51 / 51 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)